### PR TITLE
CDMS-194: Update github publish workflow to create test coverage report

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-#      - name: Create Test Coverage Reports
-#        run: |
-#          npm ci
-#          npm run build
-#          npm test
+      - name: Create Test Coverage Reports
+        run: |
+          npm ci
+          npm test
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@master


### PR DESCRIPTION
The sonarqube code analysis is not currently code coverage on the `main` branch.
The publish github workflow now executes `npm run test` in order to execute the unit tests & produce the necessary `LCOV files` for sonarqube to determine the code coverage for the `main` branch.

https://eaflood.atlassian.net/browse/CDMS-194