### PR TITLE
CDMS-356: Implement pre-notification enhanced search

### DIFF
--- a/src/services/btms-api-client.js
+++ b/src/services/btms-api-client.js
@@ -40,6 +40,15 @@ const getPreNotificationByChedRef = async (chedRef) => {
   }
 }
 
+const getPreNotificationByPartialChedRef = async (chedRef) => {
+  try {
+    return await invokeApi(`/${apiResources.PRE_NOTIFICATIONS}?filter=endsWith(id,%27${chedRef}%27)`)
+  } catch (err) {
+    logger.error(err)
+    return null
+  }
+}
+
 const getPreNotificationsByChedRefs = async (chedRefs) => {
   try {
     const formattedChedRefs = chedRefs.map(ref => `%27${ref}%27`).join(',')
@@ -64,5 +73,6 @@ export {
   getCustomsDeclarationByMovementRefNum,
   getCustomsDeclarationsByMovementRefNums,
   getPreNotificationsByChedRefs,
-  getPreNotificationByChedRef
+  getPreNotificationByChedRef,
+  getPreNotificationByPartialChedRef
 }

--- a/src/services/search-constants.js
+++ b/src/services/search-constants.js
@@ -12,7 +12,10 @@ const searchTypes = {
   PRE_NOTIFICATION_PARTIAL_REF: 'partial-ref-pre-notification'
 }
 
+const CDS_CHED_REF_PREFIX = 'GBCHD'
+
 export {
+  CDS_CHED_REF_PREFIX,
   searchPatterns,
   searchTypes
 }

--- a/test/unit/services/btms-api-client.test.js
+++ b/test/unit/services/btms-api-client.test.js
@@ -4,7 +4,8 @@ import {
   getCustomsDeclarationByMovementRefNum,
   getCustomsDeclarationsByMovementRefNums,
   getPreNotificationsByChedRefs,
-  getPreNotificationByChedRef
+  getPreNotificationByChedRef,
+  getPreNotificationByPartialChedRef
 } from '../../../src/services/btms-api-client.js'
 
 const mockLogError = jest.fn()
@@ -65,6 +66,12 @@ describe('btms-api-client', () => {
       makeAssertions(result, `/import-notifications/${testChedRef}`)
     })
 
+    test('should retrieve pre-notification by partial CHED ref successfully', async () => {
+      const result = await getPreNotificationByPartialChedRef(testChedRef)
+
+      makeAssertions(result, `/import-notifications?filter=endsWith(id,%27${testChedRef}%27)`)
+    })
+
     test('should retrieve multiple pre-notifications successfully', async () => {
       const result = await getPreNotificationsByChedRefs([testChedRef, anotherTestChedRef])
 
@@ -101,6 +108,12 @@ describe('btms-api-client', () => {
 
     test('should handle errors when retrieving a pre-notification by CHED reference', async () => {
       const result = await getPreNotificationByChedRef(testChedRef)
+
+      makeAssertions(result)
+    })
+
+    test('should handle errors when retrieving a pre-notification by partial CHED reference', async () => {
+      const result = await getPreNotificationByPartialChedRef(testChedRef)
 
       makeAssertions(result)
     })


### PR DESCRIPTION
It is now possible to search for pre-notifications by:
- CDS CHED reference e.g. `GBCHD2024.1234567`
- partial CHED reference e.g. `2024.1234567` `1234567`

https://eaflood.atlassian.net/browse/CDMS-356