### PR TITLE
Cdms 394 commodity description tooltip

### DIFF
--- a/src/client/stylesheets/_app-search-result.scss
+++ b/src/client/stylesheets/_app-search-result.scss
@@ -54,6 +54,13 @@
     text-decoration: underline dotted;
     text-underline-position: under;
     cursor: help;
+    font-size: 1rem;
+    line-height: 1.25;
+  }
+
+  &__match--yes {
+    font-size: 1rem;
+    line-height: 1.25;
   }
 
   &__match--no-tooltip,
@@ -65,6 +72,8 @@
     z-index: 9999;
     background-color: govuk-colour("light-grey");
     box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
+    font-size: 1rem;
+    line-height: 1.25;
   }
 
   &__description--tooltip {

--- a/src/client/stylesheets/_app-search-result.scss
+++ b/src/client/stylesheets/_app-search-result.scss
@@ -56,7 +56,8 @@
     cursor: help;
   }
 
-  &__match--no-tooltip {
+  &__match--no-tooltip,
+  &__description--tooltip {
     visibility: hidden;
     position: absolute;
     padding: govuk-spacing(2);
@@ -66,14 +67,23 @@
     box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.3);
   }
 
-  .govuk-table__cell:has(&__match--no-tooltip) {
+  &__description--tooltip {
+    width: 20em;
+  }
+
+  .govuk-table__cell:has(&__match--no-tooltip),
+  .govuk-table__cell:has(&__description--tooltip) {
     cursor: help;
   }
 
   .govuk-table__cell:hover &__match--no-tooltip,
   .govuk-table__cell:focus &__match--no-tooltip,
   .tooltip-container:hover &__match--no-tooltip,
-  .tooltip-container:focus &__match--no-tooltip {
+  .tooltip-container:focus &__match--no-tooltip,
+  .govuk-table__cell:hover &__description--tooltip,
+  .govuk-table__cell:focus &__description--tooltip,
+  .tooltip-container:hover &__description--tooltip,
+  .tooltip-container:focus &__description--tooltip {
     visibility: visible;
   }
 

--- a/src/templates/search-results.njk
+++ b/src/templates/search-results.njk
@@ -27,6 +27,13 @@
   {% endif %}
 {% endmacro %}
 
+{% macro commodityDescription(commodityDesc, maxLength) %}
+  {{ commodityDesc | truncate(maxLength, true) }}
+  {% if commodityDesc | length > maxLength %}
+    <p class="app-import-commodities__description--tooltip" role="tooltip">{{ commodityDesc }}</p>
+  {% endif %}
+{% endmacro %}
+
 {% set pageTitle = "Search result" %}
 
 {% block content %}
@@ -73,7 +80,7 @@
           {% set tableRows = (tableRows.push([
           { text: commodity.itemNumber },
           { text: commodity.commodityCode },
-          { text: commodity.commodityDesc },
+          { text: commodityDescription(commodity.commodityDesc, 24) },
           { text: commodity.weightOrQuantity },
           { html: customsDeclarationCHEDReferences(commodity.documents, commodity.matchStatus.unmatchedDocRefs) },
           { html: customsDeclarationMatchStatus(commodity.matchStatus.isMatched, commodity.matchStatus.unmatchedDocRefs) },
@@ -154,7 +161,12 @@
 
       {% set tableRows = [] %}
       {% for commodity in preNotification.commodities %}
-          {% set tableRows = (tableRows.push([{ text: commodity.itemNumber }, { text: commodity.commodityCode }, { text: commodity.commodityDesc }, { text: commodity.weightOrQuantity }, { text: preNotification.decision + ' (' + preNotification.authorities | join(", ") + ')'}]), tableRows) %}
+          {% set tableRows = (tableRows.push([
+          { text: commodity.itemNumber },
+          { text: commodity.commodityCode },
+          { text: commodityDescription(commodity.commodityDesc, 50) },
+          { text: commodity.weightOrQuantity },
+          { text: preNotification.decision + ' (' + preNotification.authorities | join(", ") + ')'}]), tableRows) %}
       {% endfor %}
 
       {{ govukTable({

--- a/src/templates/search-results.njk
+++ b/src/templates/search-results.njk
@@ -30,7 +30,7 @@
 {% macro commodityDescription(commodityDesc, maxLength) %}
   {{ commodityDesc | truncate(maxLength, true) }}
   {% if commodityDesc | length > maxLength %}
-    <p class="app-import-commodities__description--tooltip" role="tooltip">{{ commodityDesc }}</p>
+    <div class="app-import-commodities__description--tooltip" role="tooltip">{{ commodityDesc }}</div>
   {% endif %}
 {% endmacro %}
 

--- a/src/templates/search-results.njk
+++ b/src/templates/search-results.njk
@@ -19,10 +19,10 @@
 
 {% macro customsDeclarationMatchStatus(isMatched, unmatchedDocRefs) %}
   {% if isMatched %}
-    {{ govukTag({ text: "Yes", classes: "govuk-tag--green" }) }}
+    {{ govukTag({ text: "Yes", classes: "govuk-tag--green app-import-commodities__match--yes" }) }}
   {% else %}
     {{ govukTag({ text: "No", classes: "govuk-tag--red app-import-commodities__match--no" }) }}
-    <p class="app-import-commodities__match--no-tooltip" role="tooltip">The following CHED reference from the customs declaration cannot be found. Check the CHED reference on the customs declaration<br/>
+    <p class="app-import-commodities__match--no-tooltip" role="tooltip">The following CHED reference from the customs declaration cannot be found. Check the CHED reference on the customs declaration:<br/>
       <br/>{{ unmatchedDocRefs | join("<br/>") | safe }}</p>
   {% endif %}
 {% endmacro %}

--- a/test/unit/templates/search-results.test.js
+++ b/test/unit/templates/search-results.test.js
@@ -53,7 +53,7 @@ describe('Search Results', () => {
 
       expect($renderedTemplate.html()).not.toContain('class="error"')
       expect($renderedTemplate.html()).toContain('<li>GBCHD2024.5286242</li>')
-      expect($renderedTemplate.html()).toContain('<strong class="govuk-tag govuk-tag--green">')
+      expect($renderedTemplate.html()).toContain('<strong class="govuk-tag govuk-tag--green app-import-commodities__match--yes">')
       expect($renderedTemplate.html()).not.toContain('class="govuk-tag govuk-tag--red')
       expect($renderedTemplate.html()).not.toContain('<span class="tooltip" role="tooltip">')
     })

--- a/test/unit/templates/search-results.test.js
+++ b/test/unit/templates/search-results.test.js
@@ -1,7 +1,7 @@
 import { renderTemplate } from './template.test.helper.js'
 import { searchTypes } from '../../../src/services/search-constants.js'
 
-function createViewContext (documents, isMatched, unmatchedDocRefs, preNotificationCommodityDesc, customsDeclarationCommodityDesc) {
+function createViewContext (documents, isMatched, unmatchedDocRefs, preNotificationCommodityDesc = 'CHILLI PEPPERS', customsDeclarationCommodityDesc = 'CHILLI PEPPERS') {
   return {
     searchTerm: 'mrn-reference',
     searchType: searchTypes.CUSTOMS_DECLARATION,
@@ -14,7 +14,7 @@ function createViewContext (documents, isMatched, unmatchedDocRefs, preNotificat
         {
           itemNumber: 12074014,
           commodityCode: '0909',
-          commodityDesc: preNotificationCommodityDesc ?? 'CHILLI PEPPERS',
+          commodityDesc: preNotificationCommodityDesc,
           weightOrQuantity: 16120
         }
       ],
@@ -28,7 +28,7 @@ function createViewContext (documents, isMatched, unmatchedDocRefs, preNotificat
         {
           itemNumber: 1,
           commodityCode: '302499000',
-          commodityDesc: customsDeclarationCommodityDesc ?? 'CHILLI PEPPERS',
+          commodityDesc: customsDeclarationCommodityDesc,
           weightOrQuantity: 3471,
           documents,
           matchStatus: {
@@ -81,7 +81,7 @@ describe('Search Results', () => {
       expect($renderedTemplate.html()).toContain('A short MRN description')
       expect($renderedTemplate.html()).toContain('A short CHED description')
       expect($renderedTemplate.html()).not.toContain('...')
-      expect($renderedTemplate.html()).not.toContain('<p class="app-import-commodities__description--tooltip" role="tooltip">')
+      expect($renderedTemplate.html()).not.toContain('<div class="app-import-commodities__description--tooltip" role="tooltip">')
     })
   })
 
@@ -97,8 +97,8 @@ describe('Search Results', () => {
 
       expect($renderedTemplate.html()).toContain('A long MRN description t...')
       expect($renderedTemplate.html()).toContain('A long CHED description that should be truncated a...')
-      expect($renderedTemplate.html()).toContain('<p class="app-import-commodities__description--tooltip" role="tooltip">A long MRN description that should be truncated and displayed in full inside a tooltip</p>')
-      expect($renderedTemplate.html()).toContain('<p class="app-import-commodities__description--tooltip" role="tooltip">A long CHED description that should be truncated and displayed in full inside a tooltip</p>')
+      expect($renderedTemplate.html()).toContain('<div class="app-import-commodities__description--tooltip" role="tooltip">A long MRN description that should be truncated and displayed in full inside a tooltip</div>')
+      expect($renderedTemplate.html()).toContain('<div class="app-import-commodities__description--tooltip" role="tooltip">A long CHED description that should be truncated and displayed in full inside a tooltip</div>')
     })
   })
 })

--- a/test/unit/templates/search-results.test.js
+++ b/test/unit/templates/search-results.test.js
@@ -1,11 +1,25 @@
 import { renderTemplate } from './template.test.helper.js'
 import { searchTypes } from '../../../src/services/search-constants.js'
 
-function createViewContext (documents, isMatched, unmatchedDocRefs) {
+function createViewContext (documents, isMatched, unmatchedDocRefs, preNotificationCommodityDesc, customsDeclarationCommodityDesc) {
   return {
     searchTerm: 'mrn-reference',
     searchType: searchTypes.CUSTOMS_DECLARATION,
-    preNotifications: [],
+    preNotifications: [{
+      chedRef: 'ched.ref',
+      status: 'Validated',
+      lastUpdated: '2025-01-01 09:00:00',
+      authorities: ['PHA - FNAO'],
+      commodities: [
+        {
+          itemNumber: 12074014,
+          commodityCode: '0909',
+          commodityDesc: preNotificationCommodityDesc ?? 'CHILLI PEPPERS',
+          weightOrQuantity: 16120
+        }
+      ],
+      decision: 'Acceptable for internal market'
+    }],
     customsDeclarations: [{
       movementReferenceNumber: '24GBDX8QQ4WWFZNAR3',
       customsDeclarationStatus: 'Hold',
@@ -13,8 +27,8 @@ function createViewContext (documents, isMatched, unmatchedDocRefs) {
       commodities: [
         {
           itemNumber: 1,
-          commodityCode: 302499000,
-          commodityDesc: 'CHILLI PEPPERS',
+          commodityCode: '302499000',
+          commodityDesc: customsDeclarationCommodityDesc ?? 'CHILLI PEPPERS',
           weightOrQuantity: 3471,
           documents,
           matchStatus: {
@@ -55,6 +69,36 @@ describe('Search Results', () => {
       expect($renderedTemplate.html()).toContain('<li>GBCHD2024.5313986</li>')
       expect($renderedTemplate.html()).toContain('<strong class="govuk-tag govuk-tag--red app-import-commodities__match--no">')
       expect($renderedTemplate.html()).toContain('<p class="app-import-commodities__match--no-tooltip" role="tooltip">')
+    })
+  })
+
+  describe('With MRN that has a short description', () => {
+    test('Should not render description in tooltip', () => {
+      const viewContext = createViewContext(['GBCHD2024.5286242'], true, [], 'A short CHED description', 'A short MRN description')
+
+      $renderedTemplate = renderTemplate('search-results.njk', viewContext)
+
+      expect($renderedTemplate.html()).toContain('A short MRN description')
+      expect($renderedTemplate.html()).toContain('A short CHED description')
+      expect($renderedTemplate.html()).not.toContain('...')
+      expect($renderedTemplate.html()).not.toContain('<p class="app-import-commodities__description--tooltip" role="tooltip">')
+    })
+  })
+
+  describe('With MRN that has a long description', () => {
+    test('Should render truncated description and full description in tooltip', () => {
+      const viewContext = createViewContext(['GBCHD2024.5286242'],
+        true,
+        [],
+        'A long CHED description that should be truncated and displayed in full inside a tooltip',
+        'A long MRN description that should be truncated and displayed in full inside a tooltip')
+
+      $renderedTemplate = renderTemplate('search-results.njk', viewContext)
+
+      expect($renderedTemplate.html()).toContain('A long MRN description t...')
+      expect($renderedTemplate.html()).toContain('A long CHED description that should be truncated a...')
+      expect($renderedTemplate.html()).toContain('<p class="app-import-commodities__description--tooltip" role="tooltip">A long MRN description that should be truncated and displayed in full inside a tooltip</p>')
+      expect($renderedTemplate.html()).toContain('<p class="app-import-commodities__description--tooltip" role="tooltip">A long CHED description that should be truncated and displayed in full inside a tooltip</p>')
     })
   })
 })


### PR DESCRIPTION
Truncates commodity description and displays full description inside a tooltip, only if the description exceeds a specified length.