### PR TITLE
CDP-359: use finalisation.finalState in status

### DIFF
--- a/src/config/logger-options.js
+++ b/src/config/logger-options.js
@@ -7,7 +7,7 @@ const serviceName = config.get('serviceName')
 const serviceVersion = config.get('serviceVersion')
 
 /**
- * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": {transport: {target: string}}}}
+ * @type {{ecs: Omit<LoggerOptions, "mixin"|"transport">, "pino-pretty": LoggerOptions}}
  */
 const formatters = {
   ecs: {
@@ -16,7 +16,15 @@ const formatters = {
       serviceName
     })
   },
-  'pino-pretty': { transport: { target: 'pino-pretty' } }
+  'pino-pretty': {
+    transport: {
+      target: 'pino-pretty',
+      options: {
+        singleLine: true,
+        colorize: true
+      }
+    }
+  }
 }
 
 /**

--- a/src/models/model-constants.js
+++ b/src/models/model-constants.js
@@ -80,12 +80,23 @@ const chedDecisionDescriptions = {
   NonAcceptable: 'Non acceptable'
 }
 
+const finalStateMappings = {
+  Cleared: 'Released',
+  CancelledAfterArrival: 'Cancelled',
+  CancelledWhilePreLodged: 'Cancelled',
+  Destroyed: 'Destroyed',
+  Seized: 'Seized',
+  ReleasedToKingsWarehouse: 'Released to warehouse',
+  TransferredToMss: 'Transferred to MSS'
+}
+
 export {
   checkCodeToAuthorityMapping,
   chedDecisionDescriptions,
   chedStatusDescriptions,
   decisionCodeDescriptions,
   documentCodeToAuthorityMapping,
+  finalStateMappings,
   CHED_REF_NUMERIC_IDENTIFIER_INDEX,
   DATE_FORMAT
 }


### PR DESCRIPTION
Extend the declaration status mapping to use the finalisation object as a preference if it exists.

Also single-line the pretty logs, so they are easier to parse visually. Errors still occur on multi-line:

<img width="1264" alt="Screenshot 2025-04-09 at 4 00 31 pm" src="https://github.com/user-attachments/assets/4ee6aad1-3737-4d6e-a877-84b9ce5e8607" />
