### PR TITLE
CDMS-524: match documents using last 7 from ref

### DIFF
--- a/src/models/customs-declaration-model.js
+++ b/src/models/customs-declaration-model.js
@@ -93,10 +93,11 @@ const getMatchStatus = (documentReferences, notifications) => {
   if (!relatedPreNotifications.length) {
     return { isMatched: false, unmatchedDocRefs: documentReferences }
   }
-  // example document reference: GBCHD2024.1234567
-  const docRefNumericIdentifierIndex = 1
+  // example document reference: GBCHD2024.1234567 or GB.2024.1234567
+  const refMatchLength = 7
   const unmatchedDocRefs = documentReferences.filter(docRef =>
-    !relatedPreNotifications.includes(docRef.split('.')[docRefNumericIdentifierIndex]))
+    !relatedPreNotifications.includes(docRef.slice(-refMatchLength)))
+
   return { isMatched: !unmatchedDocRefs.length, unmatchedDocRefs }
 }
 export const createCustomsDeclarationModel = ({

--- a/test/unit/models/customs-declaration-model.test.js
+++ b/test/unit/models/customs-declaration-model.test.js
@@ -139,4 +139,49 @@ describe('#createCustomsDeclarationModel', () => {
       lastUpdated: '7 April 2025, 08:58'
     })
   })
+
+  test('matches malformed document references', () => {
+    const sourceCustomsDeclaration = {
+      entryReference: '24GBE2IL9OF0YMQAR3',
+      updatedSource: '2025-04-10T17:08:01.725Z',
+      items: [
+        {
+          itemNumber: 1,
+          taricCommodityCode: '0806101090',
+          goodsDescription: 'EDIBLE FRUIT AND NUTS',
+          itemNetMass: '16200',
+          documents: [
+            {
+              documentCode: 'N001',
+              documentReference: 'GB.2024.7654321'
+            }
+          ],
+          checks: []
+        }
+      ],
+      notifications: {
+        data: [{ id: 'GB.CHED.2024.7654321' }]
+      }
+    }
+
+    const result = createCustomsDeclarationModel(sourceCustomsDeclaration)
+
+    expect(result).toEqual({
+      movementReferenceNumber: '24GBE2IL9OF0YMQAR3',
+      commodities: [{
+        commodityCode: '0806101090',
+        commodityDesc: 'EDIBLE FRUIT AND NUTS',
+        decisions: [],
+        documents: ['GB.2024.7654321'],
+        itemNumber: 1,
+        matchStatus: {
+          isMatched: true,
+          unmatchedDocRefs: []
+        },
+        weightOrQuantity: '16200'
+      }],
+      customsDeclarationStatus: 'Released',
+      lastUpdated: '10 April 2025, 17:08'
+    })
+  })
 })


### PR DESCRIPTION
As document references are manually entered and can be malformed, comparing the last 7 digits instead of assuming that the second chunk of the string split on `.`

Will be able to revisit this once the matching logic is moved to the backend.