### PR TITLE
CDMS-367 - Update entra Id auth strategy ( fix redirect_uri )

### DIFF
--- a/src/plugins/auth/open-id.js
+++ b/src/plugins/auth/open-id.js
@@ -29,7 +29,9 @@ const openId = {
 
       const entra = await openIdProvider('entraId', entraId)
       server.auth.strategy('entraId', 'bell', {
-        location: `${baseUrl}${paths.SIGNIN_ENTRA_ID_CALLBACK}`,
+        location: (_req) => {
+          return `${baseUrl}${paths.SIGNIN_ENTRA_ID_CALLBACK}`
+        },
         provider: entra,
         password: cookie.password,
         clientId: entraId.clientId,


### PR DESCRIPTION
The `hapijs/bell` library appends the request path to the `redirect_uri` query string parameter of the `authorize` request when a function is not specified for the `location` field of the strategy options.
See detail here:
https://github.com/hapijs/bell/blob/8e18eac3698b6bba7dcfc45a390238da6196cec1/lib/oauth.js#L651

The entra id auth strategy options have been changed to assign a function for `location` 

[CDMS-367](https://eaflood.atlassian.net/browse/CDMS-367)

[CDMS-367]: https://eaflood.atlassian.net/browse/CDMS-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ