### PR TITLE
CDMS-688: remove authorities from CHED summary

### DIFF
--- a/src/templates/includes/notification-summary.njk
+++ b/src/templates/includes/notification-summary.njk
@@ -20,10 +20,6 @@
       {
         key: { text: "Last updated" },
         value: { text: preNotification.updated }
-      },
-      {
-        key: { text: "Authorities" },
-        value: { text: preNotification.authorities | join(", ") }
       }
     ]
   })


### PR DESCRIPTION
`preNotification.authorities` are still used at the row level, just no longer also show in the summary.

https://eaflood.atlassian.net/browse/CDMS-688