### PR TITLE
CDMS-260: Base64json the cookie_policy cookie

### DIFF
--- a/src/plugins/cookie-policy.js
+++ b/src/plugins/cookie-policy.js
@@ -3,18 +3,11 @@ import { config } from '../config/config.js'
 const oneYearInDaysForSonar = 365
 const oneYearInMilliseconds = 60 * 60 * 24 * oneYearInDaysForSonar * 1000
 
-const parseCookiePolicy = cookiePolicyJson => {
-  try {
-    return cookiePolicyJson ? JSON.parse(cookiePolicyJson) : undefined
-  } catch (e) { // NOSONAR - Users can set whatever they want in a cookie, don't error if it's not valid
-    return undefined
-  }
-}
-
 export const cookiePolicy = {
   name: 'cookie-policy',
   async register (server) {
     server.state('cookie_policy', {
+      encoding: 'base64json',
       isSecure: config.get('isProduction'),
       ttl: oneYearInMilliseconds
     })
@@ -26,7 +19,7 @@ export const cookiePolicy = {
         response.source.context = {
           ...response.source.context,
           cookieBannerConfirmation: request.query.cookieBannerConfirmation,
-          cookiePolicy: parseCookiePolicy(request.state?.cookie_policy)
+          cookiePolicy: request.state?.cookie_policy
         }
       }
 

--- a/src/routes/cookies.js
+++ b/src/routes/cookies.js
@@ -27,7 +27,7 @@ export const cookiesPost = {
     const { 'cookies[additional]': acceptAdditionalCookies, previousUrl } = request.payload
     const acceptedCookies = acceptAdditionalCookies === 'yes'
 
-    h.state('cookie_policy', JSON.stringify({ analytics: acceptedCookies }))
+    h.state('cookie_policy', { analytics: acceptedCookies })
 
     if (previousUrl === '/cookies') {
       return h.view('cookies', { acceptedCookies, cookiePageConfirmation: true })

--- a/test/integration/cookie-banner.test.js
+++ b/test/integration/cookie-banner.test.js
@@ -31,7 +31,7 @@ test('when cookie policy has been accepted, the cookie banner is not visible', a
 
   const { payload } = await server.inject({
     headers: {
-      Cookie: 'cookie_policy={"analytics":true}'
+      Cookie: 'cookie_policy=' + Buffer.from('{"analytics":true}').toString('base64')
     },
     method: 'get',
     url: paths.LANDING
@@ -52,7 +52,7 @@ test('when user accepts additional cookies, the cookie is set with analytics as 
     url: `${paths.COOKIES}`
   })
 
-  expect(JSON.parse(request._states.cookie_policy.value)).toEqual({ analytics: true })
+  expect(request._states.cookie_policy.value).toEqual({ analytics: true })
 })
 
 test('when user rejects additional cookies, the cookie is set with analytics as false', async () => {
@@ -67,7 +67,7 @@ test('when user rejects additional cookies, the cookie is set with analytics as 
     url: `${paths.COOKIES}`
   })
 
-  expect(JSON.parse(request._states.cookie_policy.value)).toEqual({ analytics: false })
+  expect(request._states.cookie_policy.value).toEqual({ analytics: false })
 })
 
 test('when user clicks accept or reject in the cookie banner, they are redirected back to their original location', async () => {
@@ -90,7 +90,7 @@ test('when the user has accepted cookies, after redirecting they are shown a con
 
   const { payload } = await server.inject({
     headers: {
-      Cookie: 'cookie_policy={"analytics":true}'
+      Cookie: 'cookie_policy=' + Buffer.from('{"analytics":true}').toString('base64')
     },
     method: 'get',
     url: `${paths.LANDING}?cookieBannerConfirmation=true`
@@ -104,7 +104,7 @@ test('when the user has rejected cookies, after redirecting they are shown a con
 
   const { payload } = await server.inject({
     headers: {
-      Cookie: 'cookie_policy={"analytics":true}'
+      Cookie: 'cookie_policy=' + Buffer.from('{"analytics":true}').toString('base64')
     },
     method: 'get',
     url: `${paths.LANDING}?cookieBannerConfirmation=true`

--- a/test/integration/cookies.test.js
+++ b/test/integration/cookies.test.js
@@ -39,7 +39,7 @@ test('agreeing to accept additional cookies sets the cookie_policy cookie correc
 
   expect(statusCode).toBe(httpConstants.HTTP_STATUS_OK)
   expect(payload).toContain('You’ve set your cookie preferences.')
-  expect(JSON.parse(request._states.cookie_policy.value)).toEqual({ analytics: true })
+  expect(request._states.cookie_policy.value).toEqual({ analytics: true })
 })
 
 test('rejecting additional cookies sets the cookie_policy cookie correctly', async () => {
@@ -56,7 +56,7 @@ test('rejecting additional cookies sets the cookie_policy cookie correctly', asy
 
   expect(statusCode).toBe(httpConstants.HTTP_STATUS_OK)
   expect(payload).toContain('You’ve set your cookie preferences.')
-  expect(JSON.parse(request._states.cookie_policy.value)).toEqual({ analytics: false })
+  expect(request._states.cookie_policy.value).toEqual({ analytics: false })
 })
 
 test('POSTing to the /cookies endpoint with an invalid payload returns a 404', async () => {

--- a/test/integration/search-result.test.js
+++ b/test/integration/search-result.test.js
@@ -154,7 +154,7 @@ test('shows search results', async () => {
       credentials
     },
     headers: {
-      Cookie: 'cookie_policy={"analytics":true}'
+      Cookie: 'cookie_policy=' + Buffer.from('{"analytics":true}').toString('base64')
     }
   })
 


### PR DESCRIPTION
The current implementation is to stringify the JSON object which contains the analytics config value for the tracking preference cookie. This is valid, but causes the CDP Defra ID stub to throw an exception because it does not know how to parse the cookie.

This uses Hapi's base64json encoding for the cookie instead as a workaround for the issue, which stringifies and then base64 encodes the object.