### PR TITLE
CDMS-260: Hide the cookie banner on error pages, delete cookie_policy if invalid

### DIFF
--- a/src/plugins/cookie-policy.js
+++ b/src/plugins/cookie-policy.js
@@ -7,6 +7,7 @@ export const cookiePolicy = {
   name: 'cookie-policy',
   async register (server) {
     server.state('cookie_policy', {
+      clearInvalid: true,
       encoding: 'base64json',
       isSecure: config.get('isProduction'),
       ttl: oneYearInMilliseconds

--- a/src/plugins/error-page.js
+++ b/src/plugins/error-page.js
@@ -41,7 +41,7 @@ export const errorPage = {
       const heading = titles[statusCode] || 'Sorry, there is a problem with this service'
       const messages = paragraphs[statusCode] || ['Try again later']
 
-      return h.view('error', { heading, messages })
+      return h.view('error', { heading, hideCookieBanner: true, messages })
         .code(statusCode)
     })
   }

--- a/src/templates/layout.njk
+++ b/src/templates/layout.njk
@@ -52,7 +52,7 @@
 {% set headerOptions = defaultHeaderOptions | merge(additionalHeaderOptions) %}
 
 {% block header %}
-  {% if currentUrl != "/cookies" and (cookiePolicy == null or cookieBannerConfirmation != null) %}
+  {% if currentUrl != "/cookies" and (cookiePolicy == null or cookieBannerConfirmation != null) and hideCookieBanner != true %}
     {% include "./includes/cookie-banner.njk" %}
   {% endif %}
   {{ govukHeader(headerOptions) }}

--- a/test/integration/cookie-banner.test.js
+++ b/test/integration/cookie-banner.test.js
@@ -12,10 +12,10 @@ test('when cookie policy has not been accepted, the cookie banner is visible', a
   expect(payload).toContain('Cookies on Border Trade Matching Service')
 })
 
-test('when cookie_policy cookie is garbled, the cookie banner is visible', async () => {
+test('when cookie_policy cookie is garbled, the cookie is deleted', async () => {
   const server = await initialiseServer()
 
-  const { payload } = await server.inject({
+  const { request } = await server.inject({
     headers: {
       Cookie: 'cookie_policy=anfojaenojas'
     },
@@ -23,7 +23,9 @@ test('when cookie_policy cookie is garbled, the cookie banner is visible', async
     url: paths.LANDING
   })
 
-  expect(payload).toContain('Cookies on Border Trade Matching Service')
+  const cookiePolicyRemoval = request.response.headers['set-cookie'].reduce(c => c.startsWith('cookie_policy'))
+
+  expect(cookiePolicyRemoval).toContain('Max-Age=0')
 })
 
 test('when cookie policy has been accepted, the cookie banner is not visible', async () => {
@@ -111,4 +113,15 @@ test('when the user has rejected cookies, after redirecting they are shown a con
   })
 
   expect(payload).toContain('You’ve rejected additional cookies.')
+})
+
+test('the cookie banner is not displayed on an error page', async () => {
+  const server = await initialiseServer()
+
+  const { payload } = await server.inject({
+    method: 'get',
+    url: '/404'
+  })
+
+  expect(payload).not.toContain('Cookies on Border Trade Matching Service')
 })


### PR DESCRIPTION
We don't seem to have access to the state on error pages, so we can't determine if a user has accepted cookies or not.  This change makes it so that the cookie banner is never shown on error pages.

The cookie_policy cookie has also been configured to delete itself if it is invalid.  An error page is still shown briefly but if the user reloads it shows the correct response.