### PR TITLE
CDMS-665: account management and sign out links

### DIFF
--- a/src/routes/signed-out.js
+++ b/src/routes/signed-out.js
@@ -1,9 +1,19 @@
+import joi from 'joi'
 import { paths } from './route-constants.js'
 
 export const signedOut = {
   method: 'get',
   path: paths.SIGNED_OUT,
-  handler: async (_request, h) => {
-    return h.view('signed-out', { signInUrl: paths.SIGN_IN })
+  options: {
+    validate: {
+      query: joi.object({
+        provider: joi.string()
+      })
+    }
+  },
+  handler: async (request, h) => {
+    const { provider } = request.query
+    const signInUrl = provider === 'entraId' ? paths.SIGN_IN_ENTRA : paths.SIGN_IN
+    return h.view('signed-out', { signInUrl })
   }
 }

--- a/src/templates/layout.njk
+++ b/src/templates/layout.njk
@@ -7,46 +7,21 @@
   <link href="{{ getAssetPath('stylesheets/application.scss') }}" rel="stylesheet">
 {% endblock %}
 
-{%
-  set defaultHeaderOptions = {
-    homepageUrl: "https://www.gov.uk",
-    serviceName: serviceName,
-    useTudorCrown: true
-  }
-%}
+{% set additionalHeaderOptions = {
+  navigationClasses: 'btms-header-nav',
+  useTudorCrown: true
+} %}
 
-{%
-  set navigationOptions = {
-    navigationClasses: 'btms-header-nav',
-    navigation: [{
-      text: 'Manage account',
-      href: 'https://your-account.cpdev.cui.defra.gov.uk/management'
-    }, {
-      text: 'Sign out',
-      href: signOutUrl
-    }]
-  }
-%}
-
-{% if authedUser.isAuthenticated %}
-  {% set defaultHeaderOptions = defaultHeaderOptions | merge(navigationOptions) %}
-{% endif %}
-
-{% set additionalHeaderOptions = {} %}
 {% set wrapperClass = 'govuk-main-wrapper' %}
 
 {% if landingPage %}
   {% set wrapperClass = 'btms-landing-page-wrapper' %}
-  {% set additionalHeaderOptions = {
-    classes: 'btms-landing-page-header'
-  } %}
+  {% set additionalHeaderOptions = additionalHeaderOptions | merge({ classes: 'btms-landing-page-header' }) %}
 {% endif %}
 
 {% if resultsPage %}
   {% set containerClasses = 'btms-width-container--wide' %}
-  {% set additionalHeaderOptions = {
-    containerClasses: containerClasses
-  } %}
+  {% set additionalHeaderOptions = additionalHeaderOptions | merge({ containerClasses: containerClasses }) %}
 {% endif %}
 
 {% set headerOptions = defaultHeaderOptions | merge(additionalHeaderOptions) %}

--- a/test/integration/signed-out.test.js
+++ b/test/integration/signed-out.test.js
@@ -3,16 +3,30 @@ import { getByRole } from '@testing-library/dom'
 import { initialiseServer } from '../utils/initialise-server.js'
 import { paths } from '../../src/routes/route-constants.js'
 
-test('not authenticated', async () => {
+test('signed out from defraId', async () => {
   const server = await initialiseServer()
 
   const { payload } = await server.inject({
     method: 'get',
-    url: paths.SIGNED_OUT
+    url: `${paths.SIGNED_OUT}?provider=defraId`
   })
 
   globalJsdom(payload)
 
   expect(getByRole(document.body, 'link', { name: 'Sign in' }))
     .toHaveAttribute('href', '/sign-in')
+})
+
+test('signed out from entraId', async () => {
+  const server = await initialiseServer()
+
+  const { payload } = await server.inject({
+    method: 'get',
+    url: `${paths.SIGNED_OUT}?provider=entraId`
+  })
+
+  globalJsdom(payload)
+
+  expect(getByRole(document.body, 'link', { name: 'Sign in' }))
+    .toHaveAttribute('href', '/sign-in-entra')
 })

--- a/test/unit/plugins/template-rendering/context.test.js
+++ b/test/unit/plugins/template-rendering/context.test.js
@@ -1,97 +1,113 @@
-import { createAuthedUser } from '../../utils/session-helper.js'
-import { getUserSession } from '../../../../src/auth/user-session.js'
+import { context } from '../../../../src/plugins/template-renderer/context'
+import { config } from '../../../../src/config/config.js'
 
-const mockReadFileSync = jest.fn()
-const mockLoggerError = jest.fn()
-
-jest.mock('node:fs', () => ({
-  ...jest.requireActual('node:fs'),
-  readFileSync: () => mockReadFileSync()
-}))
-jest.mock('../../../../src/utils/logger.js', () => ({
-  createLogger: () => ({ error: (...args) => mockLoggerError(...args) })
-}))
+const mockGetUserSession = jest.fn()
 
 jest.mock('../../../../src/auth/user-session.js', () => ({
-  getUserSession: jest.fn()
+  getUserSession: () => mockGetUserSession()
 }))
 
-describe('#context', () => {
-  const mockRequest = { path: '/' }
-  let contextResult
+jest.mock('node:fs', () => ({
+  readFileSync: jest.fn().mockReturnValue(JSON.stringify({
+    'application.js': 'javascripts/application.HASH.js'
+  }))
+}))
 
-  describe('When webpack manifest file read succeeds', () => {
-    let contextImport, authedUser
-
-    beforeAll(async () => {
-      contextImport = await import('../../../../src/plugins/template-renderer/context.js')
-
-      authedUser = createAuthedUser()
-      getUserSession.mockReturnValue(authedUser)
-    })
-
-    beforeEach(async () => {
-      // Return JSON string
-      mockReadFileSync.mockReturnValue(`{
-        "application.js": "javascripts/application.js",
-        "stylesheets/application.scss": "stylesheets/application.css"
-      }`)
-
-      contextResult = await contextImport.context(mockRequest)
-    })
-
-    test('Should read file', () => {
-      expect(mockReadFileSync).toHaveBeenCalled()
-    })
-
-    test('Should use cache', () => {
-      expect(mockReadFileSync).not.toHaveBeenCalled()
-    })
-
-    test('Should provide expected context', () => {
-      expect(contextResult).toEqual({
-        authedUser,
-        assetPath: '/public/assets',
-        getAssetPath: expect.any(Function),
-        serviceName: 'Border Trade Matching Service',
-        signOutUrl: '/sign-out'
-      })
-    })
-
-    describe('With valid asset path', () => {
-      test('Should provide expected asset path', () => {
-        expect(contextResult.getAssetPath('application.js')).toBe(
-          '/public/javascripts/application.js'
-        )
-      })
-    })
-
-    describe('With invalid asset path', () => {
-      test('Should provide expected asset', () => {
-        expect(contextResult.getAssetPath('an-image.png')).toBe(
-          '/public/an-image.png'
-        )
-      })
-    })
+test('logged in: defraId', async () => {
+  mockGetUserSession.mockReturnValue({
+    strategy: 'defraId',
+    isAuthenticated: true
   })
 
-  describe('When webpack manifest file read fails', () => {
-    let contextImport
+  const expected = {
+    assetPath: '/public/assets',
+    defaultHeaderOptions: {
+      homepageUrl: 'https://www.gov.uk',
+      serviceName: 'Border Trade Matching Service',
+      navigation: [
+        {
+          text: 'Manage account',
+          href: 'https://your-account.cpdev.cui.defra.gov.uk/management'
+        },
+        { text: 'Sign out', href: '/sign-out?provider=defraId' }
+      ]
+    },
+    getAssetPath: expect.any(Function)
+  }
 
-    beforeAll(async () => {
-      contextImport = await import('../../../../src/plugins/template-renderer/context.js')
-    })
+  const result = await context({})
 
-    beforeEach(() => {
-      mockReadFileSync.mockReturnValue(new Error('File not found'))
+  expect(result).toEqual(expected)
+})
 
-      contextResult = contextImport.context(mockRequest)
-    })
-
-    test('Should log that the Webpack Manifest file is not available', () => {
-      expect(mockLoggerError).toHaveBeenCalledWith(
-        'Webpack assets-manifest.json not found'
-      )
-    })
+test('logged in: entraId', async () => {
+  mockGetUserSession.mockReturnValue({
+    strategy: 'entraId',
+    isAuthenticated: true
   })
+
+  const expected = {
+    assetPath: '/public/assets',
+    defaultHeaderOptions: {
+      homepageUrl: 'https://www.gov.uk',
+      serviceName: 'Border Trade Matching Service',
+      navigation: [
+        { text: 'Sign out', href: '/sign-out?provider=entraId' }
+      ]
+    },
+    getAssetPath: expect.any(Function)
+  }
+
+  const result = await context({})
+
+  expect(result).toEqual(expected)
+})
+
+test('not logged in', async () => {
+  mockGetUserSession.mockReturnValue(null)
+
+  const request = {
+    logger: { error: jest.fn() }
+  }
+
+  const expected = {
+    assetPath: '/public/assets',
+    defaultHeaderOptions: {
+      homepageUrl: 'https://www.gov.uk',
+      serviceName: 'Border Trade Matching Service',
+      navigation: []
+    },
+    getAssetPath: expect.any(Function)
+  }
+
+  const result = await context(request)
+
+  expect(result).toEqual(expected)
+})
+
+test('getAssetPath(): returns hashed path', async () => {
+  mockGetUserSession.mockReturnValue(null)
+  config.set('assetPath', '/test')
+
+  const { getAssetPath } = await context({})
+
+  expect(getAssetPath('application.js'))
+    .toBe('/test/javascripts/application.HASH.js')
+})
+
+test('getAssetPath(): logs error for unmapped files', async () => {
+  mockGetUserSession.mockReturnValue(null)
+  config.set('assetPath', '/test')
+
+  const request = {
+    logger: { error: jest.fn() }
+  }
+
+  const { getAssetPath } = await context(request)
+
+  expect(getAssetPath('not-built-with-webpack.js'))
+    .toBe('/test/undefined')
+  expect(request.logger.error.mock.calls).toEqual([
+    ['Asset not-built-with-webpack.js not found in manifest']
+  ])
 })


### PR DESCRIPTION
* only show account management if logged in with DefraId
* signed-out page dynamically links back to Defra or Entra sign in paths
* hoist header options up into context
* allow manifest loading to fail and error
* log if there's ever an attempt to load a file not in the manifest

https://eaflood.atlassian.net/browse/CDMS-665