### PR TITLE
CDMS-767 - Add config for the defra id account management URL

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -296,6 +296,12 @@ const config = convict({
         sensitive: true,
         env: 'AUTH_DEFRA_ID_ORGANISATIONS',
         default: ['7f2f65e0-4858-11f0-afd0-f3af378128f9']
+      },
+      accountManagementUrl: {
+        doc: 'Defra ID account management portal URL',
+        format: String,
+        env: 'AUTH_DEFRA_ID_ACCOUNT_MANAGEMENT_URL',
+        default: '#'
       }
     },
     entraId: {

--- a/src/plugins/template-renderer/context.js
+++ b/src/plugins/template-renderer/context.js
@@ -27,9 +27,10 @@ export async function context (request) {
   const navigation = []
 
   if (authedUser?.strategy === 'defraId') {
+    const accountManagementUrl = config.get('auth.defraId.accountManagementUrl')
     navigation.push({
       text: 'Manage account',
-      href: 'https://your-account.cpdev.cui.defra.gov.uk/management'
+      href: accountManagementUrl
     })
   }
   if (authedUser?.isAuthenticated) {

--- a/test/unit/plugins/template-rendering/context.test.js
+++ b/test/unit/plugins/template-rendering/context.test.js
@@ -27,7 +27,7 @@ test('logged in: defraId', async () => {
       navigation: [
         {
           text: 'Manage account',
-          href: 'https://your-account.cpdev.cui.defra.gov.uk/management'
+          href: '#'
         },
         { text: 'Sign out', href: '/sign-out?provider=defraId' }
       ]


### PR DESCRIPTION
To enable the 'Manage account' link to be configured on a per environment basis.