### PR TITLE
CDMS-571: Log error data

### DIFF
--- a/src/plugins/error-page.js
+++ b/src/plugins/error-page.js
@@ -36,6 +36,9 @@ export const errorPage = {
 
       if (statusCode >= HTTP_STATUS_INTERNAL_SERVER_ERROR) {
         request.logger.error(response.stack)
+        if (response.data) {
+          request.logger.error(JSON.stringify(response.data))
+        }
       }
 
       const heading = titles[statusCode] || 'Sorry, there is a problem with this service'


### PR DESCRIPTION
To help diagnose why the token request to entra id is failing.
( the `data` property of the boom error is now explicitly logged)