### PR TITLE
Error logging - remove use of json stringify

### DIFF
--- a/src/plugins/error-page.js
+++ b/src/plugins/error-page.js
@@ -37,7 +37,7 @@ export const errorPage = {
       if (statusCode >= HTTP_STATUS_INTERNAL_SERVER_ERROR) {
         request.logger.error(response.stack)
         if (response.data) {
-          request.logger.error(JSON.stringify(response.data))
+          request.logger.error(response.data)
         }
       }
 


### PR DESCRIPTION
To avoid potential circular reference errors that may manifest when using `JSON.stringify` 