### PR TITLE
CDMS-878: Redirect unauthorized users on secure pages to /signed-out

### DIFF
--- a/src/plugins/error-page.js
+++ b/src/plugins/error-page.js
@@ -8,13 +8,11 @@ const {
 } = constants
 
 const titles = {
-  [HTTP_STATUS_UNAUTHORIZED]: 'Sign in',
   [HTTP_STATUS_FORBIDDEN]: 'You do not have the correct permissions to access this service',
   [HTTP_STATUS_NOT_FOUND]: 'Page not found'
 }
 
 const paragraphs = {
-  [HTTP_STATUS_UNAUTHORIZED]: ['You need to sign in to this service.'],
   [HTTP_STATUS_FORBIDDEN]: ['Contact your organisation’s administrator if you need access.'],
   [HTTP_STATUS_NOT_FOUND]: [
     'If you typed the web address, check it is correct.',
@@ -52,6 +50,10 @@ export const errorPage = {
       }
 
       const { statusCode } = response.output
+
+      if (statusCode === HTTP_STATUS_UNAUTHORIZED) {
+        return h.redirect('/signed-out')
+      }
 
       if (statusCode >= HTTP_STATUS_INTERNAL_SERVER_ERROR) {
         request.logger.error(response.stack)

--- a/test/integration/error-page.test.js
+++ b/test/integration/error-page.test.js
@@ -2,7 +2,6 @@ import boom from '@hapi/boom'
 import globalJsdom from 'global-jsdom'
 import { getByRole } from '@testing-library/dom'
 import { initialiseServer } from '../utils/initialise-server.js'
-import { paths as PATHS } from '../../src/routes/route-constants.js'
 
 test('400: bad request', async () => {
   const server = await initialiseServer()
@@ -35,15 +34,13 @@ test('401: unauthorized should redirect to /signed-out', async () => {
     handler: (_request, h) => boom.unauthorized()
   })
 
-  const { headers, payload, statusCode } = await server.inject({
+  const { headers, statusCode } = await server.inject({
     method: 'get',
     url: '/simulate-unauthorized-error'
   })
 
-  globalJsdom(payload)
-
   expect(statusCode).toBe(302)
-  expect(headers.location).toContain(PATHS.SIGNED_OUT)
+  expect(headers.location).toContain('/signed-out')
 })
 
 test('403: forbidden', async () => {

--- a/test/integration/error-page.test.js
+++ b/test/integration/error-page.test.js
@@ -2,6 +2,7 @@ import boom from '@hapi/boom'
 import globalJsdom from 'global-jsdom'
 import { getByRole } from '@testing-library/dom'
 import { initialiseServer } from '../utils/initialise-server.js'
+import { paths as PATHS } from '../../src/routes/route-constants.js'
 
 test('400: bad request', async () => {
   const server = await initialiseServer()
@@ -26,7 +27,7 @@ test('400: bad request', async () => {
     .toBe('Sorry, there is a problem with this service - Border Trade Matching Service')
 })
 
-test('401: unauthorized', async () => {
+test('401: unauthorized should redirect to /signed-out', async () => {
   const server = await initialiseServer()
   server.route({
     method: 'get',
@@ -34,19 +35,15 @@ test('401: unauthorized', async () => {
     handler: (_request, h) => boom.unauthorized()
   })
 
-  const { payload, statusCode } = await server.inject({
+  const { headers, payload, statusCode } = await server.inject({
     method: 'get',
     url: '/simulate-unauthorized-error'
   })
 
   globalJsdom(payload)
 
-  expect(statusCode).toBe(401)
-  getByRole(document.body, 'heading', {
-    name: 'Sign in'
-  })
-  expect(document.title)
-    .toBe('Sign in - Border Trade Matching Service')
+  expect(statusCode).toBe(302)
+  expect(headers.location).toContain(PATHS.SIGNED_OUT)
 })
 
 test('403: forbidden', async () => {

--- a/test/integration/search-result.test.js
+++ b/test/integration/search-result.test.js
@@ -290,7 +290,7 @@ test('redirects to search page for incorrect search', async () => {
   expect(headers.location).toBe(paths.SEARCH)
 })
 
-test('rejects non authorised requests', async () => {
+test('redirect non authorised requests', async () => {
   wreck.get
     .mockResolvedValueOnce({ payload: provider })
     .mockResolvedValueOnce({ payload: provider })
@@ -302,7 +302,7 @@ test('rejects non authorised requests', async () => {
     url: `${paths.SEARCH_RESULT}?${queryStringParams.SEARCH_TERM}=24GB0Z8WEJ9ZBTL73Y`
   })
 
-  expect(statusCode).toBe(401)
+  expect(statusCode).toBe(302)
 })
 
 test('handles upstream errors', async () => {

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -89,7 +89,7 @@ test('renders search page with error', async () => {
     .toBe(null)
 })
 
-test('rejects non authorised requests', async () => {
+test('redirect non authorised requests', async () => {
   const server = await initialiseServer()
 
   const { statusCode } = await server.inject({
@@ -97,5 +97,5 @@ test('rejects non authorised requests', async () => {
     url: paths.SEARCH
   })
 
-  expect(statusCode).toBe(401)
+  expect(statusCode).toBe(302)
 })


### PR DESCRIPTION
The current 401 page does not have a button to sign in, meaning the users are stuck with no way to continue.
This change redirects any 401 pages to /signed-out which currently contains a button to log in via GG.