### PR TITLE
CDMS-399: use speciesId along with complementId

### DIFF
--- a/src/models/pre-notifications.js
+++ b/src/models/pre-notifications.js
@@ -105,8 +105,11 @@ const getChedPPChecks = (preNotification, complementParameterSet) => {
 const mapCommodity = (commodityComplement, preNotification) => {
   const { complementParameterSets } = preNotification.partOne.commodities
   const { importNotificationType } = preNotification
-  const complementParameterSet = complementParameterSets
-    .find(({ complementId }) => complementId === commodityComplement.complementId)
+  const complementParameterSet = complementParameterSets.find(
+    ({ complementId, speciesId }) =>
+      complementId === commodityComplement.complementId &&
+      speciesId === commodityComplement.speciesId
+  )
 
   const commodityDesc = commodityComplement.speciesName ||
     commodityComplement.commodityDescription ||


### PR DESCRIPTION
Sometimes CHEDPPs have split commodities which get given the same complementId, have observed that the speciesId is still different so comparing both.