### PR TITLE
CDMS-882: Iterate over decisions to populate decisions column

### DIFF
--- a/src/templates/includes/declaration-html.njk
+++ b/src/templates/includes/declaration-html.njk
@@ -27,18 +27,16 @@
           {{ documentReference(decision) }}
           <td class="govuk-table__cell">{{ decisionMatch(decision.match) }}</td>
           <td class="govuk-table__cell btms-decision-outcomes">
-            {% for outcome in decision.outcomes %}
-              {% if loop.first %} <ul class="govuk-list"> {% endif %}
+            <ul class="govuk-list">
               <li
-                data-decision="{{ outcome.decision }}"
-                data-authority="{{ outcome.departmentCode }}"
+                data-decision="{{ decision.outcome.decision }}"
+                data-authority="{{ decision.outcome.departmentCode }}"
               >
-                {% if outcome.decision %}
-                  {{ outcome.decision }} -
-                {% endif %} {{ outcome.decisionDetail }} ({{ outcome.departmentCode }})
+                {% if decision.outcome.decision %}
+                  {{ decision.outcome.decision }} -
+                {% endif %} {{ decision.outcome.decisionDetail }} ({{ decision.outcome.departmentCode }})
               </li>
-              {% if loop.last %} </ul> {% endif %}
-            {% endfor %}
+            </ul>
         </tr>
       {% endfor %}
     </tbody>

--- a/test/unit/models/customs-declarations.test.js
+++ b/test/unit/models/customs-declarations.test.js
@@ -63,20 +63,24 @@ test('MRN, open, finalised, using netMass, matched', () => {
           id: expect.any(String),
           documentReference: 'GBCHD2025.1234567',
           match: true,
-          outcomes: [{
+          outcome: {
             decision: 'Release',
             decisionDetail: 'Inspection complete',
-            departmentCode: 'FNAO'
-          }]
+            decisionReason: null,
+            departmentCode: 'FNAO',
+            isIuuOutcome: false
+          }
         }, {
           id: expect.any(String),
           documentReference: null,
           match: null,
-          outcomes: [{
+          outcome: {
             decision: 'Release',
             decisionDetail: 'IUU inspection complete',
-            departmentCode: 'IUU'
-          }]
+            decisionReason: null,
+            departmentCode: 'IUU',
+            isIuuOutcome: true
+          }
         }],
         documents: {
           'GBCHD2025.1234567': ['C678'],
@@ -148,25 +152,25 @@ test('MRN, open, manual release, using supplementaryUnits, no decisions', () => 
           id: expect.any(String),
           documentReference: 'GBCHD2025.1234567',
           match: false,
-          outcomes: [{
+          outcome: {
             decision: '',
+            decisionReason: null,
             decisionDetail: undefined,
-            departmentCode: 'PHSI'
-          }, {
-            decision: '',
-            decisionDetail: undefined,
-            departmentCode: 'PHSI'
-          }]
+            departmentCode: 'PHSI',
+            isIuuOutcome: false
+          }
         }, {
           id: expect.any(String),
           documentReference: null,
           match: null,
-          outcomes: [
+          outcome:
             {
               decision: '',
               decisionDetail: undefined,
-              departmentCode: 'IUU'
-            }]
+              decisionReason: null,
+              departmentCode: 'IUU',
+              isIuuOutcome: true
+            }
         }],
         documents: {
           'GBCHD2025.1234567': ['N851', '9115'],
@@ -226,11 +230,13 @@ test('de-dupes document references', () => {
         id: expect.any(String),
         documentReference: 'GBCHD2025.0000001',
         match: false,
-        outcomes: [{
+        outcome: {
           decision: '',
           decisionDetail: undefined,
-          departmentCode: 'POAO'
-        }]
+          decisionReason: null,
+          departmentCode: 'POAO',
+          isIuuOutcome: false
+        }
       }],
       documents: {
         'GBCHD2025.0000001': ['N853']
@@ -287,11 +293,13 @@ test('matches malformed references', () => {
         id: expect.any(String),
         documentReference: 'GB.CHD.2025.0000002',
         match: true,
-        outcomes: [{
+        outcome: {
           decision: '',
           decisionDetail: undefined,
-          departmentCode: 'FNAO'
-        }]
+          decisionReason: null,
+          departmentCode: 'FNAO',
+          isIuuOutcome: false
+        }
       }],
       checks: [{ checkCode: 'H223' }],
       documents: {

--- a/test/unit/models/customs-declarations.test.js
+++ b/test/unit/models/customs-declarations.test.js
@@ -105,6 +105,72 @@ test('MRN, open, finalised, using netMass, matched', () => {
   expect(result).toEqual(expected)
 })
 
+test('an MRN, with no CHED, with no documents returns expected response', () => {
+  const data = {
+    customsDeclarations: [{
+      movementReferenceNumber: 'GB251234567890ABCD',
+      clearanceRequest: {
+        declarationUcr: '5GB123456789000-BDOV123456',
+        commodities: [{
+          itemNumber: 1,
+          netMass: '9999',
+          checks: [{
+            checkCode: 'H220'
+          }]
+        }]
+      },
+      clearanceDecision: {
+        items: [{
+          itemNumber: 1,
+          checks: [{
+            decisionCode: 'X00',
+            checkCode: 'H220'
+          }]
+        }]
+      },
+      finalisation: null,
+      updated: '2025-05-12T11:13:17.330Z'
+    }],
+    importPreNotifications: []
+  }
+
+  const result = mapCustomsDeclarations(data)
+
+  const expected = [{
+    commodities: [
+      {
+        id: expect.any(String),
+        decisions: [{
+          id: expect.any(String),
+          documentReference: null,
+          match: false,
+          outcome: {
+            decision: '',
+            decisionDetail: 'No match',
+            decisionReason: null,
+            departmentCode: 'HMI',
+            isIuuOutcome: false
+          }
+        }],
+        documents: {},
+        checks: [
+          { checkCode: 'H220' }
+        ],
+        itemNumber: 1,
+        netMass: '9999',
+        weightOrQuantity: '9999'
+      }
+    ],
+    movementReferenceNumber: 'GB251234567890ABCD',
+    declarationUcr: '5GB123456789000-BDOV123456',
+    open: true,
+    status: 'Current',
+    updated: '12 May 2025, 11:13'
+  }]
+
+  expect(result).toEqual(expected)
+})
+
 test('MRN, open, manual release, using supplementaryUnits, no decisions', () => {
   const data = {
     customsDeclarations: [{


### PR DESCRIPTION
Currently the UI iterates over the documents in a commodity to generate the info for the decisions column.
This is problematic in the case where a CHED is required by CDS to be created because there are no documents to iterate over.

This changes the logic to use the decisions array instead for the decisions column, picking up the documents where necessary.