### PR TITLE
CDMS-882: Display a Requires CHED text if the import has been selected for inspection

### DIFF
--- a/src/models/customs-declarations.js
+++ b/src/models/customs-declarations.js
@@ -25,6 +25,7 @@ const isRefusalDecisionCode = (decisionCode) => {
 const isReleaseDecisionCode = (decisionCode) => {
   return hasDesiredPrefix(decisionCode, 'c0')
 }
+const requiresChed = (check, documents) => check.checkCode === 'H220' && check.decisionCode === 'X00' && documents.length === 0
 
 export const getDecision = (decisionCode) => {
   let decisionHighLevelDesc
@@ -94,8 +95,7 @@ const mapCommodity = (commodity, notificationStatuses, clearanceDecision) => {
     return {
       ...check,
       decisionCode: decision?.decisionCode,
-      decisionReasons: decision?.decisionReasons,
-      decisionInternalFurtherDetail: decision?.decisionInternalFurtherDetail
+      decisionReasons: decision?.decisionReasons
     }
   })
 
@@ -111,7 +111,8 @@ const mapCommodity = (commodity, notificationStatuses, clearanceDecision) => {
       decisionDetail: getDecisionDescription(check.decisionCode, notificationStatus),
       decisionReason: check.decisionReasons?.length > 0 ? check.decisionReasons[0] : null,
       departmentCode: checkCodeToAuthorityMapping[check.checkCode],
-      isIuuOutcome: relevantDocuments.some(doc => IUUDocumentReferences.includes(doc))
+      isIuuOutcome: relevantDocuments.some(doc => IUUDocumentReferences.includes(doc)),
+      requiresChed: requiresChed(check, checkDocuments)
     }
 
     const isIuuOutcome = relevantDocuments.some(doc => IUUDocumentReferences.includes(doc))

--- a/src/templates/macros/document-reference.njk
+++ b/src/templates/macros/document-reference.njk
@@ -4,10 +4,17 @@
   {% else %}
     {% set id = 'tooltip-' + decision.id %}
     <td class="govuk-table__cell btms-no-match" tabindex="0" aria-describedby="{{ id }}">
-      {{ decision.documentReference }}
-      <span role="tooltip" id="{{ id }}">
-        This CHED reference cannot be found on the customs declaration. Please check that the reference is correct.
-      </span>
+      {% if decision.outcome.requiresChed %}
+        Requires CHED
+        <span role="tooltip" id="{{ id }}">
+          {{ decision.outcome.decisionReason }}
+        </span>
+      {% else %}
+        {{ decision.documentReference }}
+        <span role="tooltip" id="{{ id }}">
+          This CHED reference cannot be found on the customs declaration. Please check that the reference is correct.
+        </span>
+      {% endif %}
     </td>
   {% endif %}
 {% endmacro%}

--- a/test/integration/search-result.test.js
+++ b/test/integration/search-result.test.js
@@ -52,6 +52,12 @@ const customsDeclarations = [{
         documentCode: 'N002'
       }],
       checks: [{ checkCode: 'H220', departmentCode: 'HMI' }]
+    }, {
+      itemNumber: 4,
+      taricCommodityCode: '3120232190',
+      goodsDescription: 'CHICKEN 7000 KG',
+      netMass: '7000',
+      checks: [{ checkCode: 'H220', departmentCode: 'HMI' }]
     }]
   },
   clearanceDecision: {
@@ -72,6 +78,13 @@ const customsDeclarations = [{
       checks: [{
         checkCode: 'H220',
         decisionCode: 'X00'
+      }]
+    }, {
+      itemNumber: 4,
+      checks: [{
+        checkCode: 'H220',
+        decisionCode: 'X00',
+        decisionReasons: ['Needs a CHED']
       }]
     }]
   },
@@ -165,6 +178,12 @@ test('shows search results', async () => {
 
   const declaration = getByRole(document.body, 'group', { name: '24GB0Z8WEJ9ZBTL73B' })
   expect(declaration).toHaveAttribute('open')
+
+  const declarationRow4 = getByRole(declaration, 'row', {
+    name: '4 3120232190 CHICKEN 7000 KG 7000 Requires CHED Needs a CHED No No match (HMI)'
+  })
+  const requiresChedTooltip = declarationRow4.getElementsByTagName('span')
+  expect(requiresChedTooltip[0].innerHTML.trim()).toBe('Needs a CHED')
 
   const declarationRow3 = getByRole(declaration, 'row', {
     name: '3 1602321990 JBB VIENNESE ROAST 2 KG 87.07 CHEDP.BB.2025.NOMATCH This CHED reference cannot be found on the customs declaration. Please check that the reference is correct. No No match (HMI)'

--- a/test/unit/models/customs-declarations.test.js
+++ b/test/unit/models/customs-declarations.test.js
@@ -68,7 +68,8 @@ test('MRN, open, finalised, using netMass, matched', () => {
             decisionDetail: 'Inspection complete',
             decisionReason: null,
             departmentCode: 'FNAO',
-            isIuuOutcome: false
+            isIuuOutcome: false,
+            requiresChed: false
           }
         }, {
           id: expect.any(String),
@@ -79,7 +80,8 @@ test('MRN, open, finalised, using netMass, matched', () => {
             decisionDetail: 'IUU inspection complete',
             decisionReason: null,
             departmentCode: 'IUU',
-            isIuuOutcome: true
+            isIuuOutcome: true,
+            requiresChed: false
           }
         }],
         documents: {
@@ -149,7 +151,8 @@ test('an MRN, with no CHED, with no documents returns expected response', () => 
             decisionDetail: 'No match',
             decisionReason: null,
             departmentCode: 'HMI',
-            isIuuOutcome: false
+            isIuuOutcome: false,
+            requiresChed: true
           }
         }],
         documents: {},
@@ -223,7 +226,8 @@ test('MRN, open, manual release, using supplementaryUnits, no decisions', () => 
             decisionReason: null,
             decisionDetail: undefined,
             departmentCode: 'PHSI',
-            isIuuOutcome: false
+            isIuuOutcome: false,
+            requiresChed: false
           }
         }, {
           id: expect.any(String),
@@ -235,7 +239,8 @@ test('MRN, open, manual release, using supplementaryUnits, no decisions', () => 
               decisionDetail: undefined,
               decisionReason: null,
               departmentCode: 'IUU',
-              isIuuOutcome: true
+              isIuuOutcome: true,
+              requiresChed: false
             }
         }],
         documents: {
@@ -301,7 +306,8 @@ test('de-dupes document references', () => {
           decisionDetail: undefined,
           decisionReason: null,
           departmentCode: 'POAO',
-          isIuuOutcome: false
+          isIuuOutcome: false,
+          requiresChed: false
         }
       }],
       documents: {
@@ -364,7 +370,8 @@ test('matches malformed references', () => {
           decisionDetail: undefined,
           decisionReason: null,
           departmentCode: 'FNAO',
-          isIuuOutcome: false
+          isIuuOutcome: false,
+          requiresChed: false
         }
       }],
       checks: [{ checkCode: 'H223' }],


### PR DESCRIPTION
Some imports do not normally require CHEDs to be created, however some are randomly chosen for inspection which requires a CHED.

This adds in the ability to show this message if the criteria for to show the message has been met.