### PR TITLE
CDMS-845: Allow optional V and R suffix on end of CHEDs

### DIFF
--- a/src/services/search-patterns.js
+++ b/src/services/search-patterns.js
@@ -6,22 +6,22 @@ export const searchPatterns = [
   },
   {
     key: 'chedId',
-    pattern: /^CHED([ADP]|P{2})\.GB\.2\d{3}\.\d{7}$/,
+    pattern: /^CHED([ADP]|P{2})\.GB\.2\d{3}\.\d{7}[VR]?$/,
     description: 'CHED'
   },
   {
     key: 'chedId',
-    pattern: /^GBCHD2\d{3}\.\d{7}$/,
+    pattern: /^GBCHD2\d{3}\.\d{7}[VR]?$/,
     description: 'CDS CHED'
   },
   {
     key: 'chedId',
-    pattern: /^2\d{3}\.\d{7}$/,
+    pattern: /^2\d{3}\.\d{7}[VR]?$/,
     description: 'Partial CHED'
   },
   {
     key: 'chedId',
-    pattern: /^\d{7}$/,
+    pattern: /^\d{7}[VR]?$/,
     description: 'last 7 digits of a CHED'
   },
   {

--- a/test/unit/services/search-patterns.test.js
+++ b/test/unit/services/search-patterns.test.js
@@ -1,0 +1,24 @@
+import { searchPatterns } from '../../../src/services/search-patterns.js'
+
+test.each([
+  ['CHEDA.GB.2025.0000001', true],
+  ['CHEDA.GB.2025.000000', false],
+  ['CHEDA.GB.2025.0000001V', true],
+  ['CHEDA.GB.2025.0000001R', true],
+  ['0000001', true],
+  ['000000', false],
+  ['0000001V', true],
+  ['0000001R', true],
+  ['GBCHD2024.5286242', true],
+  ['GBCHD2024.528624', false],
+  ['GBCHD2024.5286242V', true],
+  ['GBCHD2024.5286242R', true]
+])('The search pattern test for %s should equal %s', (search, expected) => {
+  const searchPattern = searchPatterns.find(({ pattern }) => pattern.test(search))
+  if (expected) {
+    expect(searchPattern).toBeDefined()
+    return
+  }
+
+  expect(searchPattern).toBeUndefined()
+})


### PR DESCRIPTION
Some of the CHEDs are split consignments, gaining a V or R on the end.