### PR TITLE
CDMS-315: Update content-security-policy for google analytics

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -342,7 +342,7 @@ const config = convict({
     }
   },
   gtmId: {
-    doc: 'Google Tag Manager ID',
+    doc: 'Google Tag Manager container identifier',
     format: String,
     default: 'GTM-PSCS57N9',
     env: 'GTM_ID'

--- a/src/plugins/security-headers.js
+++ b/src/plugins/security-headers.js
@@ -7,8 +7,8 @@ export const securityHeaders = {
           "default-src 'self'; " +
           `script-src 'self' 'nonce-${request.app.cspNonce}'; ` +
           "style-src 'self'; " +
-          "img-src 'self' data: www.googletagmanager.com; " +
-          "connect-src 'self' www.googletagmanager.com www.google.com; " +
+          "img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; " +
+          "connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; " +
           "frame-ancestors 'none'; " +
           "base-uri 'self'; " +
           "form-action 'self';",

--- a/test/integration/security-headers.test.js
+++ b/test/integration/security-headers.test.js
@@ -15,7 +15,7 @@ test('common responses', async () => {
 
   expect(headers)
     .toEqual({
-      'content-security-policy': "default-src 'self'; script-src 'self' 'nonce-random'; style-src 'self'; img-src 'self' data: www.googletagmanager.com; connect-src 'self' www.googletagmanager.com www.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
+      'content-security-policy': "default-src 'self'; script-src 'self' 'nonce-random'; style-src 'self'; img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com; connect-src 'self' https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
       'cross-origin-opener-policy': 'same-origin',
       'cross-origin-resource-policy': 'same-origin',
       'origin-agent-cluster': '?1',


### PR DESCRIPTION
To resolve the content-security-policy issue that is preventing google analytics integration
The CSP changes are based on the [google documentation](https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics)