### PR TITLE
CDMS-798: Support document level decisions, resolve issue with displaying legacy documents

### DIFF
--- a/src/client/javascripts/filters.js
+++ b/src/client/javascripts/filters.js
@@ -1,7 +1,7 @@
 const filterTypes = {
   declaration: {
     all: ['decision', 'authority', 'match'],
-    list: ['decision', 'authority'],
+    list: ['decision', 'authority', 'match'],
     row: ['match']
   },
   notification: {
@@ -86,23 +86,7 @@ const setEmptyState = (table, type) => {
 }
 
 const setRow = (state, type, row) => {
-  const decisionsList = row.querySelector('ul')
-  const listItems = [...decisionsList.querySelectorAll('li')]
-
-  listItems.forEach((li) => {
-    li.hidden = filterTypes[type].list.some((key) =>
-      state[key] && li.dataset[key] !== state[key]
-    )
-  })
-
-  const rowHidden = filterTypes[type].row.some((key) =>
-    state[key] && row.dataset[key] !== state[key]
-  )
-
-  row.hidden = Boolean(
-    decisionsList.querySelectorAll('li:not([hidden])').length === 0 ||
-    rowHidden
-  )
+  row.hidden = filterTypes[type].list.some(key => state[key] && row.dataset[key] !== state[key])
 }
 
 const setRows = (state, type) => {

--- a/src/models/customs-declarations.js
+++ b/src/models/customs-declarations.js
@@ -6,7 +6,7 @@ import {
   closedChedStatuses,
   checkCodeToAuthorityMapping,
   finalStateMappings,
-  IUUDocumentReferences,
+  IUUDocumentCodes,
   DATE_FORMAT
 } from './model-constants.js'
 
@@ -36,7 +36,6 @@ const isRefusalDecisionCode = (decisionCode) => {
 const isReleaseDecisionCode = (decisionCode) => {
   return hasDesiredPrefix(decisionCode, 'c0')
 }
-const requiresChed = (check, documents) => check.checkCode === 'H220' && check.decisionCode === 'X00' && documents.length === 0
 
 export const getDecision = (decisionCode) => {
   let decisionHighLevelDesc
@@ -100,73 +99,70 @@ export const getCustomsDeclarationOpenState = (finalisation) => !(
   (finalisation.finalState === '1' || finalisation.finalState === '2')
 )
 
+const mapLegacyDecisions = (commodity, clearanceDecision) => {
+  return commodity.checks.map(check => {
+    const associatedDocumentCodes = checkCodeToDocumentCodeMapping[check.checkCode]
+    const associatedDocuments = (commodity.documents || []).filter(doc => associatedDocumentCodes.includes(doc.documentCode))
+
+    if (associatedDocuments.length === 0) {
+      const clearanceDecisionCheck = clearanceDecision?.checks.find(({ checkCode }) => checkCode === check.checkCode)
+      return [
+        {
+          itemNumber: commodity.itemNumber,
+          documentReference: null,
+          checkCode: check.checkCode,
+          decisionCode: clearanceDecisionCheck?.decisionCode,
+          decisionReason: clearanceDecisionCheck?.decisionReasons?.length > 0 ? clearanceDecisionCheck?.decisionReasons[0] : null
+        }
+      ]
+    }
+
+    return associatedDocuments.map(doc => {
+      const decision = clearanceDecision?.checks.find(({ checkCode }) => checkCode === check.checkCode)
+
+      return {
+        itemNumber: commodity.itemNumber,
+        documentReference: doc.documentReference,
+        checkCode: check.checkCode,
+        decisionCode: decision?.decisionCode,
+        decisionReason: decision?.decisionReasons?.length > 0 ? decision?.decisionReasons[0] : null
+      }
+    })
+  }).flat()
+}
+
 const mapCommodity = (commodity, notificationStatuses, clearanceDecision) => {
-  const documents = (commodity.documents || [])
-    .reduce((docs, doc) => {
-      const references = docs[doc.documentReference] || []
-      docs[doc.documentReference] = [...new Set(references.concat(doc.documentCode))]
-      return docs
-    }, {})
+  const decisions = clearanceDecision?.results && clearanceDecision.results.length > 0 ? clearanceDecision.results : mapLegacyDecisions(commodity, clearanceDecision)
+  const allDecisionCodesAreNoMatch = decisions.every(decision => decision.decisionCode === 'X00')
+  const iuuRelatedChedpCheck = decisions.find(decision => decision.checkCode === 'H222')
 
-  const weightOrQuantity = Number(commodity.netMass)
-    ? commodity.netMass
-    : commodity.supplementaryUnits
+  const clearanceDecisions = decisions.filter(result => result.itemNumber === commodity.itemNumber)
+    .map(decision => {
+      const documentReferenceId = decision.documentReference ? extractDocumentReferenceId(decision.documentReference) : null
+      const notificationStatus = documentReferenceId ? notificationStatuses[documentReferenceId] : null
+      const relevantDocCodes = checkCodeToDocumentCodeMapping[decision.checkCode]
+      const isIuuOutcome = relevantDocCodes.some(code => IUUDocumentCodes.includes(code))
 
-  const decisionChecks = clearanceDecision
-    ? clearanceDecision.items
-      .filter(({ itemNumber }) => itemNumber === commodity.itemNumber)
-      .flatMap(({ checks }) => checks)
-    : []
-
-  const checksWithDecisionCodes = commodity.checks.map((check) => {
-    const decision = decisionChecks
-      .find(({ checkCode }) => checkCode === check.checkCode)
-
-    return {
-      ...check,
-      decisionCode: decision?.decisionCode,
-      decisionReasons: decision?.decisionReasons
-    }
-  })
-
-  const allDecisionCodesAreNoMatch = checksWithDecisionCodes.every((check) => {
-    return check.decisionCode === 'X00'
-  })
-
-  const iuuRelatedChedpCheck = checksWithDecisionCodes.find((check) => check.checkCode === 'H222')
-
-  const decisions = checksWithDecisionCodes.map(check => {
-    const relevantDocuments = checkCodeToDocumentCodeMapping[check.checkCode]
-    const checkDocuments = (commodity.documents || []).filter(doc => relevantDocuments.includes(doc.documentCode))
-    const documentReference = (checkDocuments.length > 0) ? checkDocuments[0].documentReference : null
-    const documentReferenceId = documentReference ? extractDocumentReferenceId(documentReference) : null
-    const notificationStatus = documentReferenceId ? notificationStatuses[documentReferenceId] : null
-
-    const isIuuOutcome = relevantDocuments.some(doc => IUUDocumentReferences.includes(doc))
-
-    const outcome = {
-      decision: getDecision(check.decisionCode),
-      decisionDetail: getDecisionDescription(check.decisionCode, notificationStatus, isIuuOutcome, allDecisionCodesAreNoMatch, iuuRelatedChedpCheck),
-      decisionReason: check.decisionReasons?.length > 0 ? check.decisionReasons[0] : null,
-      departmentCode: checkCodeToAuthorityMapping[check.checkCode],
-      isIuuOutcome: relevantDocuments.some(doc => IUUDocumentReferences.includes(doc)),
-      requiresChed: requiresChed(check, checkDocuments)
-    }
-
-    return {
-      id: randomUUID(),
-      documentReference: isIuuOutcome ? null : documentReference,
-      outcome,
-      match: isIuuOutcome ? null : Boolean(notificationStatus)
-    }
-  }).sort((a, b) => a.outcome.isIuuOutcome - b.outcome.isIuuOutcome)
+      return {
+        id: randomUUID(),
+        decision: getDecision(decision.decisionCode),
+        decisionDetail: getDecisionDescription(decision.decisionCode, notificationStatus, isIuuOutcome, allDecisionCodesAreNoMatch, iuuRelatedChedpCheck),
+        decisionReason: decision.decisionReason,
+        departmentCode: checkCodeToAuthorityMapping[decision.checkCode],
+        documentReference: isIuuOutcome ? null : decision.documentReference,
+        isIuuOutcome,
+        requiresChed: decision.documentReference == null && decision.checkCode === 'H220',
+        match: isIuuOutcome ? null : Boolean(notificationStatus)
+      }
+    }).sort((a, b) => a.isIuuOutcome - b.isIuuOutcome)
 
   return {
     id: randomUUID(),
     ...commodity,
-    documents,
-    weightOrQuantity,
-    decisions
+    weightOrQuantity: Number(commodity.netMass)
+      ? commodity.netMass
+      : commodity.supplementaryUnits,
+    decisions: clearanceDecisions
   }
 }
 
@@ -174,7 +170,7 @@ const mapCustomsDeclaration = (declaration, notificationStatuses) => {
   const { clearanceRequest, clearanceDecision, finalisation } = declaration
   const updated = format(declaration.updated, DATE_FORMAT)
   const commodities = clearanceRequest.commodities
-    .map((commodity) => mapCommodity(commodity, notificationStatuses, clearanceDecision))
+    .map(commodity => mapCommodity(commodity, notificationStatuses, (clearanceDecision?.items || []).find(({ itemNumber }) => itemNumber === commodity.itemNumber)))
 
   const status = getCustomsDeclarationStatus(finalisation)
   const open = getCustomsDeclarationOpenState(finalisation)

--- a/src/models/model-constants.js
+++ b/src/models/model-constants.js
@@ -68,7 +68,7 @@ export const checkCodeToDocumentCodeMapping = {
   H224: ['C673', 'C641']
 }
 
-export const IUUDocumentReferences = ['C641', 'C673']
+export const IUUDocumentCodes = ['C641', 'C673']
 
 export const chedStatusDescriptions = {
   CANCELLED: 'Cancelled',

--- a/src/templates/includes/declaration-html.njk
+++ b/src/templates/includes/declaration-html.njk
@@ -19,24 +19,22 @@
   {% for commodity in customsDeclaration.commodities %}
     <tbody class="govuk-table__body">
       {% for decision in commodity.decisions %}
-        <tr data-match="{{ decision.match }}">
+        <tr data-match="{{ decision.match }}" data-authority="{{ decision.departmentCode }}" data-decision="{{ decision.decision }}">
           <td class="govuk-table__cell">{{ commodity.itemNumber }}</td>
           <td class="govuk-table__cell">{{ commodity.taricCommodityCode }}</td>
           <td class="govuk-table__cell">{{ commodityDescription(commodity.goodsDescription, commodity.id, maxLength) }}</td>
           <td class="govuk-table__cell">{{ commodity.weightOrQuantity }}</td>
-          {{ documentReference(decision) }}
-          <td class="govuk-table__cell">{{ decisionMatch(decision.match) }}</td>
-          <td class="govuk-table__cell btms-decision-outcomes">
-            <ul class="govuk-list">
-              <li
-                data-decision="{{ decision.outcome.decision }}"
-                data-authority="{{ decision.outcome.departmentCode }}"
-              >
-                {% if decision.outcome.decision %}
-                  {{ decision.outcome.decision }} -
-                {% endif %} {{ decision.outcome.decisionDetail }} ({{ decision.outcome.departmentCode }})
-              </li>
-            </ul>
+          {% if not decision.isIuuOutcome %}
+            {{ documentReference(decision) }}
+            <td class="govuk-table__cell">{{ decisionMatch(decision.match) }}</td>
+          {% else %}
+            <td class="govuk-table__cell" colspan="2"></td>
+          {% endif %}
+          <td class="govuk-table__cell">
+            {% if decision.decision %}
+              {{ decision.decision }} -
+            {% endif %} {{ decision.decisionDetail }} ({{ decision.departmentCode }})
+          </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/src/templates/macros/document-reference.njk
+++ b/src/templates/macros/document-reference.njk
@@ -4,10 +4,10 @@
   {% else %}
     {% set id = 'tooltip-' + decision.id %}
     <td class="govuk-table__cell btms-no-match" tabindex="0" aria-describedby="{{ id }}">
-      {% if decision.outcome.requiresChed %}
+      {% if decision.requiresChed %}
         Requires CHED
         <span role="tooltip" id="{{ id }}">
-          {{ decision.outcome.decisionReason }}
+          {{ decision.decisionReason }}
         </span>
       {% else %}
         {{ decision.documentReference }}

--- a/test/unit/models/customs-declarations.test.js
+++ b/test/unit/models/customs-declarations.test.js
@@ -63,31 +63,33 @@ test('MRN, open, finalised, using netMass, matched', () => {
           id: expect.any(String),
           documentReference: 'GBCHD2025.1234567',
           match: true,
-          outcome: {
-            decision: 'Release',
-            decisionDetail: 'Inspection complete',
-            decisionReason: null,
-            departmentCode: 'FNAO',
-            isIuuOutcome: false,
-            requiresChed: false
-          }
+          decision: 'Release',
+          decisionDetail: 'Inspection complete',
+          decisionReason: null,
+          departmentCode: 'FNAO',
+          isIuuOutcome: false,
+          requiresChed: false
         }, {
           id: expect.any(String),
           documentReference: null,
           match: null,
-          outcome: {
-            decision: 'Release',
-            decisionDetail: 'IUU inspection complete',
-            decisionReason: null,
-            departmentCode: 'IUU',
-            isIuuOutcome: true,
-            requiresChed: false
-          }
+          decision: 'Release',
+          decisionDetail: 'IUU inspection complete',
+          decisionReason: null,
+          departmentCode: 'IUU',
+          isIuuOutcome: true,
+          requiresChed: false
         }],
-        documents: {
-          'GBCHD2025.1234567': ['C678'],
-          'IGNORED IUUD DOCUMENT': ['C641']
-        },
+        documents: [
+          {
+            documentCode: 'C641',
+            documentReference: 'IGNORED IUUD DOCUMENT'
+          },
+          {
+            documentCode: 'C678',
+            documentReference: 'GBCHD2025.1234567'
+          }
+        ],
         checks: [
           { checkCode: 'H224' },
           { checkCode: 'H223' }
@@ -191,21 +193,23 @@ test('a split consignment with a matching document returns expected response', (
               documentReference: 'GBCHD2025.1234567V',
               id: expect.any(String),
               match: true,
-              outcome: {
-                decision: '',
-                decisionDetail: undefined,
-                decisionReason: null,
-                departmentCode: 'APHA',
-                isIuuOutcome: false,
-                requiresChed: false
-              }
+              decision: '',
+              decisionDetail: undefined,
+              decisionReason: null,
+              departmentCode: 'APHA',
+              isIuuOutcome: false,
+              requiresChed: false
             }
           ],
-          documents: {
-            'GBCHD2025.1234567V': [
-              'C640'
-            ]
-          },
+          documents: [
+            {
+              documentCode: 'C640',
+              documentControl: 'P',
+              documentQuantity: null,
+              documentReference: 'GBCHD2025.1234567V',
+              documentStatus: 'AE'
+            }
+          ],
           goodsDescription: 'FAT SAUSAGES',
           id: expect.any(String),
           itemNumber: 1,
@@ -310,21 +314,23 @@ test('a split consignment without a matching document returns expected response'
               documentReference: 'GBCHD2025.1999997V',
               id: expect.any(String),
               match: false,
-              outcome: {
-                decision: '',
-                decisionDetail: undefined,
-                decisionReason: null,
-                departmentCode: 'APHA',
-                isIuuOutcome: false,
-                requiresChed: false
-              }
+              decision: '',
+              decisionDetail: undefined,
+              decisionReason: null,
+              departmentCode: 'APHA',
+              isIuuOutcome: false,
+              requiresChed: false
             }
           ],
-          documents: {
-            'GBCHD2025.1999997V': [
-              'C640'
-            ]
-          },
+          documents: [
+            {
+              documentCode: 'C640',
+              documentControl: 'P',
+              documentQuantity: null,
+              documentReference: 'GBCHD2025.1999997V',
+              documentStatus: 'AE'
+            }
+          ],
           goodsDescription: 'FAT SAUSAGES',
           id: expect.any(String),
           itemNumber: 1,
@@ -384,16 +390,13 @@ test('an MRN, with no CHED, with no documents returns expected response', () => 
           id: expect.any(String),
           documentReference: null,
           match: false,
-          outcome: {
-            decision: '',
-            decisionDetail: 'No match',
-            decisionReason: null,
-            departmentCode: 'HMI',
-            isIuuOutcome: false,
-            requiresChed: true
-          }
+          decision: '',
+          decisionDetail: 'No match',
+          decisionReason: null,
+          departmentCode: 'HMI',
+          isIuuOutcome: false,
+          requiresChed: true
         }],
-        documents: {},
         checks: [
           { checkCode: 'H220' }
         ],
@@ -459,32 +462,47 @@ test('MRN, open, manual release, using supplementaryUnits, no decisions', () => 
           id: expect.any(String),
           documentReference: 'GBCHD2025.1234567',
           match: false,
-          outcome: {
-            decision: '',
-            decisionReason: null,
-            decisionDetail: undefined,
-            departmentCode: 'PHSI',
-            isIuuOutcome: false,
-            requiresChed: false
-          }
+          decision: '',
+          decisionReason: null,
+          decisionDetail: undefined,
+          departmentCode: 'PHSI',
+          isIuuOutcome: false,
+          requiresChed: false
+        }, {
+          id: expect.any(String),
+          documentReference: 'GBCHD2025.1234567',
+          match: false,
+          decision: '',
+          decisionReason: null,
+          decisionDetail: undefined,
+          departmentCode: 'PHSI',
+          isIuuOutcome: false,
+          requiresChed: false
         }, {
           id: expect.any(String),
           documentReference: null,
           match: null,
-          outcome:
-            {
-              decision: '',
-              decisionDetail: undefined,
-              decisionReason: null,
-              departmentCode: 'IUU',
-              isIuuOutcome: true,
-              requiresChed: false
-            }
+          decision: '',
+          decisionDetail: undefined,
+          decisionReason: null,
+          departmentCode: 'IUU',
+          isIuuOutcome: true,
+          requiresChed: false
         }],
-        documents: {
-          'GBCHD2025.1234567': ['N851', '9115'],
-          'IGNORED IUUD DOCUMENT': ['C641']
-        },
+        documents: [
+          {
+            documentCode: 'N851',
+            documentReference: 'GBCHD2025.1234567'
+          },
+          {
+            documentCode: '9115',
+            documentReference: 'GBCHD2025.1234567'
+          },
+          {
+            documentCode: 'C641',
+            documentReference: 'IGNORED IUUD DOCUMENT'
+          }
+        ],
         checks: [
           { checkCode: 'H224' },
           { checkCode: 'H219' }
@@ -499,68 +517,6 @@ test('MRN, open, manual release, using supplementaryUnits, no decisions', () => 
     open: true,
     status: 'Finalised - Manually released',
     updated: '12 May 2025, 12:42'
-  }]
-
-  expect(result).toEqual(expected)
-})
-
-test('de-dupes document references', () => {
-  const data = {
-    customsDeclarations: [{
-      movementReferenceNumber: 'GB2501010101010101',
-      clearanceRequest: {
-        declarationUcr: '5GB123456789000-BDOV123456',
-        commodities: [{
-          itemNumber: 1,
-          netMass: '1000',
-          documents: [{
-            documentCode: 'N853',
-            documentReference: 'GBCHD2025.0000001'
-          }, {
-            documentCode: 'N853',
-            documentReference: 'GBCHD2025.0000001'
-          }],
-          checks: [{ checkCode: 'H222' }]
-        }]
-      },
-      clearanceDecision: null,
-      finalisation: null,
-      updated: '2025-05-12T11:13:17.330Z'
-    }],
-    importPreNotifications: []
-  }
-
-  const result = mapCustomsDeclarations(data)
-
-  const expected = [{
-    commodities: [{
-      id: expect.any(String),
-      decisions: [{
-        id: expect.any(String),
-        documentReference: 'GBCHD2025.0000001',
-        match: false,
-        outcome: {
-          decision: '',
-          decisionDetail: undefined,
-          decisionReason: null,
-          departmentCode: 'POAO',
-          isIuuOutcome: false,
-          requiresChed: false
-        }
-      }],
-      documents: {
-        'GBCHD2025.0000001': ['N853']
-      },
-      checks: [{ checkCode: 'H222' }],
-      itemNumber: 1,
-      netMass: '1000',
-      weightOrQuantity: '1000'
-    }],
-    movementReferenceNumber: 'GB2501010101010101',
-    declarationUcr: '5GB123456789000-BDOV123456',
-    open: true,
-    status: 'Current',
-    updated: '12 May 2025, 11:13'
   }]
 
   expect(result).toEqual(expected)
@@ -603,19 +559,20 @@ test('matches malformed references', () => {
         id: expect.any(String),
         documentReference: 'GB.CHD.2025.0000002',
         match: true,
-        outcome: {
-          decision: '',
-          decisionDetail: undefined,
-          decisionReason: null,
-          departmentCode: 'FNAO',
-          isIuuOutcome: false,
-          requiresChed: false
-        }
+        decision: '',
+        decisionDetail: undefined,
+        decisionReason: null,
+        departmentCode: 'FNAO',
+        isIuuOutcome: false,
+        requiresChed: false
       }],
       checks: [{ checkCode: 'H223' }],
-      documents: {
-        'GB.CHD.2025.0000002': ['C678']
-      },
+      documents: [
+        {
+          documentCode: 'C678',
+          documentReference: 'GB.CHD.2025.0000002'
+        }
+      ],
       itemNumber: 1,
       netMass: '500',
       weightOrQuantity: '500'
@@ -624,6 +581,231 @@ test('matches malformed references', () => {
     declarationUcr: '5GB123456789000-BDOV123456',
     open: true,
     status: 'Current',
+    updated: '12 May 2025, 11:13'
+  }]
+
+  expect(result).toEqual(expected)
+})
+
+test('parses and returns document level decisions correctly', () => {
+  const data = {
+    customsDeclarations: [{
+      movementReferenceNumber: 'GB251234567890ABCD',
+      clearanceRequest: {
+        declarationUcr: '5GB123456789000-BDOV123456',
+        commodities: [{
+          itemNumber: 1,
+          netMass: '9999',
+          documents: [
+            {
+              documentCode: 'N851',
+              documentReference: 'GBCHD2025.9710001',
+              documentStatus: 'AE',
+              documentControl: 'P',
+              documentQuantity: null
+            },
+            {
+              documentCode: 'N851',
+              documentReference: 'GBCHD2025.9710002',
+              documentStatus: 'AE',
+              documentControl: 'P',
+              documentQuantity: null
+            },
+            {
+              documentCode: 'N851',
+              documentReference: 'GBCHD2025.9710003',
+              documentStatus: 'AE',
+              documentControl: 'P',
+              documentQuantity: null
+            },
+            {
+              documentCode: 'N851',
+              documentReference: 'GBCHD2025.9710004',
+              documentStatus: 'AE',
+              documentControl: 'P',
+              documentQuantity: null
+            }
+          ],
+          checks: [{
+            checkCode: 'H219',
+            departmentCode: 'PHSI'
+          }]
+        }]
+      },
+      clearanceDecision: {
+        items: [{
+          itemNumber: 1,
+          checks: [
+            {
+              checkCode: 'H219',
+              decisionCode: 'N02',
+              decisionsValidUntil: null,
+              decisionReasons: [],
+              decisionInternalFurtherDetail: null
+            }
+          ]
+        }],
+        results: [
+          {
+            itemNumber: 1,
+            importPreNotification: null,
+            documentReference: 'GBCHD2025.9710004',
+            checkCode: 'H219',
+            decisionCode: 'X00',
+            decisionReason: null,
+            internalDecisionCode: null
+          },
+          {
+            itemNumber: 1,
+            importPreNotification: 'CHEDPP.GB.2025.9710001',
+            documentReference: 'GBCHD2025.9710001',
+            checkCode: 'H219',
+            decisionCode: 'C03',
+            decisionReason: null,
+            internalDecisionCode: null
+          },
+          {
+            itemNumber: 1,
+            importPreNotification: 'CHEDPP.GB.2025.9710002',
+            documentReference: 'GBCHD2025.9710002',
+            checkCode: 'H219',
+            decisionCode: 'H01',
+            decisionReason: null,
+            internalDecisionCode: null
+          },
+          {
+            itemNumber: 1,
+            importPreNotification: 'CHEDPP.GB.2025.9710003',
+            documentReference: 'GBCHD2025.9710003',
+            checkCode: 'H219',
+            decisionCode: 'N02',
+            decisionReason: null,
+            internalDecisionCode: null
+          }
+
+        ]
+      },
+      finalisation: {
+        isManualRelease: false,
+        finalState: 0
+      },
+      updated: '2025-05-12T11:13:17.330Z'
+    }],
+    importPreNotifications: [{
+      importPreNotification: {
+        referenceNumber: 'CHEDP.GB.2025.9710001',
+        status: 'VALIDATED'
+      }
+    }, {
+      importPreNotification: {
+        referenceNumber: 'CHEDP.GB.2025.9710002',
+        status: 'VALIDATED'
+      }
+    }, {
+      importPreNotification: {
+        referenceNumber: 'CHEDP.GB.2025.9710003',
+        status: 'VALIDATED'
+      }
+    }]
+  }
+
+  const result = mapCustomsDeclarations(data)
+
+  const expected = [{
+    commodities: [
+      {
+        checks: [
+          {
+            checkCode: 'H219',
+            departmentCode: 'PHSI'
+          }
+        ],
+        decisions: [
+          {
+            decision: 'Refuse',
+            decisionDetail: 'Destroy',
+            decisionReason: null,
+            departmentCode: 'PHSI',
+            documentReference: 'GBCHD2025.9710001',
+            id: expect.any(String),
+            isIuuOutcome: false,
+            match: true,
+            requiresChed: false
+          },
+          {
+            decision: 'Refuse',
+            decisionDetail: 'Destroy',
+            decisionReason: null,
+            departmentCode: 'PHSI',
+            documentReference: 'GBCHD2025.9710002',
+            id: expect.any(String),
+            isIuuOutcome: false,
+            match: true,
+            requiresChed: false
+          },
+          {
+            decision: 'Refuse',
+            decisionDetail: 'Destroy',
+            decisionReason: null,
+            departmentCode: 'PHSI',
+            documentReference: 'GBCHD2025.9710003',
+            id: expect.any(String),
+            isIuuOutcome: false,
+            match: true,
+            requiresChed: false
+          },
+          {
+            decision: 'Refuse',
+            decisionDetail: 'Destroy',
+            decisionReason: null,
+            departmentCode: 'PHSI',
+            documentReference: 'GBCHD2025.9710004',
+            id: expect.any(String),
+            isIuuOutcome: false,
+            match: false,
+            requiresChed: false
+          }
+        ],
+        documents: [
+          {
+            documentCode: 'N851',
+            documentControl: 'P',
+            documentQuantity: null,
+            documentReference: 'GBCHD2025.9710001',
+            documentStatus: 'AE'
+          },
+          {
+            documentCode: 'N851',
+            documentControl: 'P',
+            documentQuantity: null,
+            documentReference: 'GBCHD2025.9710002',
+            documentStatus: 'AE'
+          },
+          {
+            documentCode: 'N851',
+            documentControl: 'P',
+            documentQuantity: null,
+            documentReference: 'GBCHD2025.9710003',
+            documentStatus: 'AE'
+          },
+          {
+            documentCode: 'N851',
+            documentControl: 'P',
+            documentQuantity: null,
+            documentReference: 'GBCHD2025.9710004',
+            documentStatus: 'AE'
+          }
+        ],
+        id: expect.any(String),
+        itemNumber: 1,
+        netMass: '9999',
+        weightOrQuantity: '9999'
+      }
+    ],
+    declarationUcr: '5GB123456789000-BDOV123456',
+    movementReferenceNumber: 'GB251234567890ABCD',
+    open: true,
+    status: 'Finalised - Released',
     updated: '12 May 2025, 11:13'
   }]
 
@@ -746,31 +928,33 @@ test.each([
           id: expect.any(String),
           documentReference: 'GBCHD2025.1234567',
           match: true,
-          outcome: {
-            decision: options.chedDecision,
-            decisionDetail: options.chedDecisionDetail,
-            decisionReason: null,
-            departmentCode: 'POAO',
-            isIuuOutcome: false,
-            requiresChed: false
-          }
+          decision: options.chedDecision,
+          decisionDetail: options.chedDecisionDetail,
+          decisionReason: null,
+          departmentCode: 'POAO',
+          isIuuOutcome: false,
+          requiresChed: false
         }, {
           id: expect.any(String),
           documentReference: null,
           match: null,
-          outcome: {
-            decision: options.iuuDecision,
-            decisionDetail: options.iuuDecisionDetail,
-            decisionReason: null,
-            departmentCode: 'IUU',
-            isIuuOutcome: true,
-            requiresChed: false
-          }
+          decision: options.iuuDecision,
+          decisionDetail: options.iuuDecisionDetail,
+          decisionReason: null,
+          departmentCode: 'IUU',
+          isIuuOutcome: true,
+          requiresChed: false
         }],
-        documents: {
-          'GBCHD2025.1234567': ['N853'],
-          'GBIUU-VARIOUS': ['C673']
-        },
+        documents: [
+          {
+            documentCode: 'N853',
+            documentReference: 'GBCHD2025.1234567'
+          },
+          {
+            documentCode: 'C673',
+            documentReference: 'GBIUU-VARIOUS'
+          }
+        ],
         checks: [
           { checkCode: 'H222' },
           { checkCode: 'H224' }


### PR DESCRIPTION
This change adds support for displaying document level decisions, which have been added by a new field returned in the API.

To be able to support both new (document level) and legacy (worst case scenario) decisions, the system tries to convert the legacy decision into the new format.

Since the search result table is no longer based around documents, but rather decisions, the data structure has been flattened and the table layout simplified. I think we will need to revisit the filters functionality in the near future.