### PR TITLE
CDMS-798: Fallback to item level decision for requires CHED cases

### DIFF
--- a/src/models/customs-declarations.js
+++ b/src/models/customs-declarations.js
@@ -133,7 +133,9 @@ const mapLegacyDecisions = (commodity, clearanceDecision) => {
 
 const mapCommodity = (commodity, notificationStatuses, clearanceDecision) => {
   const documentLevelDecisions = clearanceDecision?.results && clearanceDecision.results.length > 0 ? clearanceDecision.results.filter(({ itemNumber }) => itemNumber === commodity.itemNumber) : null
-  const decisions = documentLevelDecisions || mapLegacyDecisions(commodity, (clearanceDecision?.items || []).find(({ itemNumber }) => itemNumber === commodity.itemNumber))
+  // Workaround until the DD outputs the checkCode as H220
+  const areAnyRequiresChedDecisions = documentLevelDecisions?.some(({ checkCode, decisionCode }) => decisionCode === 'X00' && checkCode === null) && (commodity.documents || []).length === 0
+  const decisions = (!areAnyRequiresChedDecisions && documentLevelDecisions) || mapLegacyDecisions(commodity, (clearanceDecision?.items || []).find(({ itemNumber }) => itemNumber === commodity.itemNumber))
 
   const allDecisionCodesAreNoMatch = decisions.every(decision => decision.decisionCode === 'X00')
   const iuuRelatedChedpCheck = decisions.find(decision => decision.checkCode === 'H222')

--- a/test/unit/models/customs-declarations.test.js
+++ b/test/unit/models/customs-declarations.test.js
@@ -812,6 +812,179 @@ test('parses and returns document level decisions correctly', () => {
   expect(result).toEqual(expected)
 })
 
+test('the workaround for null checkCodes when a CHED is required to be created falls back to item level decisions', () => {
+  const data = {
+    customsDeclarations: [{
+      movementReferenceNumber: 'GB251234567890ABCD',
+      clearanceRequest: {
+        declarationUcr: '5GB123456789000-BDOV123456',
+        commodities: [{
+          itemNumber: 1,
+          netMass: '9999',
+          documents: null,
+          checks: [{
+            checkCode: 'H220',
+            departmentCode: 'HMI'
+          }]
+        },
+        {
+          itemNumber: 2,
+          netMass: '9999',
+          documents: [
+            {
+              documentCode: 'N002',
+              documentReference: 'CHEDPP.GB.2025.1123456',
+              documentStatus: 'AE',
+              documentControl: 'P',
+              documentQuantity: null
+            }
+          ],
+          checks: [{
+            checkCode: 'H220',
+            departmentCode: 'HMI'
+          }]
+        }]
+      },
+      clearanceDecision: {
+        items: [{
+          itemNumber: 1,
+          checks: [
+            {
+              checkCode: 'H220',
+              decisionCode: 'X00',
+              decisionsValidUntil: null,
+              decisionReasons: ['We require you to make a CHED'],
+              decisionInternalFurtherDetail: null
+            }]
+        }, {
+          itemNumber: 2,
+          checks: [
+            {
+              checkCode: 'H220',
+              decisionCode: 'H01',
+              decisionsValidUntil: null,
+              decisionReasons: [],
+              decisionInternalFurtherDetail: null
+            }
+          ]
+        }],
+        results: [
+          {
+            itemNumber: 1,
+            importPreNotification: null,
+            documentReference: '',
+            checkCode: null,
+            decisionCode: 'X00',
+            decisionReason: null,
+            internalDecisionCode: null
+          },
+          {
+            itemNumber: 2,
+            importPreNotification: null,
+            documentReference: 'GBCHD2025.1123456',
+            checkCode: 'H220',
+            decisionCode: 'H01',
+            decisionReason: null,
+            internalDecisionCode: null
+          }
+        ]
+      },
+      finalisation: {
+        isManualRelease: false,
+        finalState: 0
+      },
+      updated: '2025-05-12T11:13:17.330Z'
+    }],
+    importPreNotifications: [{
+      importPreNotification: {
+        referenceNumber: 'CHEDP.GB.2025.9710001',
+        status: 'VALIDATED'
+      }
+    }, {
+      importPreNotification: {
+        referenceNumber: 'CHEDP.GB.2025.9710002',
+        status: 'VALIDATED'
+      }
+    }]
+  }
+
+  const result = mapCustomsDeclarations(data)
+
+  const expected = [
+    {
+      commodities: [
+        {
+          checks: [
+            {
+              checkCode: 'H220',
+              departmentCode: 'HMI'
+            }
+          ],
+          decisions: [
+            {
+              decision: '',
+              decisionDetail: 'No match',
+              decisionReason: 'We require you to make a CHED',
+              departmentCode: 'HMI',
+              documentReference: null,
+              id: expect.any(String),
+              isIuuOutcome: false,
+              match: false,
+              requiresChed: true
+            }
+          ],
+          documents: null,
+          id: expect.any(String),
+          itemNumber: 1,
+          netMass: '9999',
+          weightOrQuantity: '9999'
+        },
+        {
+          checks: [
+            {
+              checkCode: 'H220',
+              departmentCode: 'HMI'
+            }
+          ],
+          decisions: [
+            {
+              decision: 'Hold',
+              decisionDetail: 'Awaiting decision',
+              decisionReason: null,
+              departmentCode: 'HMI',
+              documentReference: 'GBCHD2025.1123456',
+              id: expect.any(String),
+              isIuuOutcome: false,
+              match: false,
+              requiresChed: false
+            }
+          ],
+          documents: [
+            {
+              documentCode: 'N002',
+              documentControl: 'P',
+              documentQuantity: null,
+              documentReference: 'CHEDPP.GB.2025.1123456',
+              documentStatus: 'AE'
+            }
+          ],
+          id: expect.any(String),
+          itemNumber: 2,
+          netMass: '9999',
+          weightOrQuantity: '9999'
+        }
+      ],
+      declarationUcr: '5GB123456789000-BDOV123456',
+      movementReferenceNumber: 'GB251234567890ABCD',
+      open: true,
+      status: 'Finalised - Released',
+      updated: '12 May 2025, 11:13'
+    }
+  ]
+
+  expect(result).toEqual(expected)
+})
+
 test('getDecision()', () => {
   expect(getDecision('C01'))
     .toBe('Release')


### PR DESCRIPTION
Currently the DD generates a document decision for a requires CHED case by returning no checkCode, which causes the UI to error.
This adds in a workaround for now to fall back to the item level decisions if any of the checkCodes are null.