### PR TITLE
CDMS-957: Show the quantity if one of the doc codes is C640

### DIFF
--- a/src/models/customs-declarations.js
+++ b/src/models/customs-declarations.js
@@ -23,17 +23,16 @@ const extractDocumentReferenceId = (documentReference) => {
 }
 
 const determineWeightOrQuantity = (commodity, decisions) => {
-  // C640/CHEDA decisions should show the quantity, otherwise the weight
-  const hasC640Decision = decisions.some(decision => {
+  const showQuantity = decisions.some(decision => {
     const relevantDocCodes = checkCodeToDocumentCodeMapping[decision.checkCode] || []
     return relevantDocCodes.includes('C640')
   })
 
-  const primary = hasC640Decision ? commodity.supplementaryUnits : commodity.netMass
-  const secondary = hasC640Decision ? commodity.netMass : commodity.supplementaryUnits
+  const primary = showQuantity ? commodity.supplementaryUnits : commodity.netMass
+  const fallbackValue = showQuantity ? commodity.netMass : commodity.supplementaryUnits
 
   if (primary == null || primary === 0 || primary === '0') {
-    return Number(secondary)
+    return Number(fallbackValue)
   }
 
   return Number(primary)


### PR DESCRIPTION
CHEDA/C640 decisions should show the quantity, not the weight.
This updates the logic to check if one of the provided documents is a C640 and then shows the quantity.

In the case of a netMass or supplementaryUnits not being provided, for whatever reason, it falls back to the other value if available.