### PR TITLE
CDMS-923: add all auth origins to CSP form actions

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -331,6 +331,11 @@ const config = convict({
         env: 'AUTH_ENTRA_ID_SCOPES',
         default: ['openid', 'offline_access']
       }
+    },
+    origins: {
+      doc: 'Auth provider origins for CSP header',
+      format: Array,
+      default: []
     }
   },
   ipaffs: {

--- a/src/plugins/security-headers.js
+++ b/src/plugins/security-headers.js
@@ -4,14 +4,7 @@ export const securityHeaders = {
   name: 'security-headers',
   async register (server) {
     server.ext('onPreResponse', (request, h) => {
-      const { defraId, entraId } = config.get('auth')
-
-      const formActions = [defraId, entraId]
-        .map(({ oidcConfigurationUrl }) => {
-          const { origin } = new URL(oidcConfigurationUrl)
-          return origin
-        })
-        .join(' ')
+      const formActions = config.get('auth').origins.join(' ')
 
       const headersToAdd = {
         'content-security-policy':

--- a/test/integration/security-headers.test.js
+++ b/test/integration/security-headers.test.js
@@ -9,8 +9,7 @@ jest.mock('node:crypto', () => ({
 test('common responses', async () => {
   const server = await initialiseServer()
 
-  config.set('auth.defraId.oidcConfigurationUrl', 'https://defraId.com/ignored-path')
-  config.set('auth.entraId.oidcConfigurationUrl', 'https://entraId.com/ignored-path')
+  config.set('auth.origins', ['https://defraid.com', 'https://entraid.com'])
 
   const { headers } = await server.inject({
     method: 'get',

--- a/test/unit/auth/open-id-provider.test.js
+++ b/test/unit/auth/open-id-provider.test.js
@@ -4,9 +4,9 @@ import { openIdProvider } from '../../../src/auth/open-id-provider.js'
 
 jest.mock('../../../src/auth/open-id-client.js', () => ({
   getOpenIdConfig: jest.fn().mockReturnValue({
-    authorization_endpoint: 'http://some-auth-endpoint',
-    token_endpoint: 'http://some-token-endpoint',
-    end_session_endpoint: 'http://some-end-session-endpoint'
+    authorization_endpoint: 'http://some-auth-endpoint/path',
+    token_endpoint: 'http://some-token-endpoint/path',
+    end_session_endpoint: 'http://some-end-session-endpoint/path'
   })
 }))
 
@@ -14,7 +14,7 @@ let provider
 
 beforeAll(async () => {
   provider = await openIdProvider('defraId', {
-    oidcConfigurationUrl: 'https://test.it'
+    oidcConfigurationUrl: 'https://test.it/path'
   })
 })
 
@@ -87,9 +87,17 @@ test('credentials exist', async () => {
     relationships: [`${currentRelationshipId}:${organisationId}`],
     roles: 'testRoles',
     idToken: 'test-id-token',
-    tokenUrl: 'http://some-token-endpoint',
-    logoutUrl: 'http://some-end-session-endpoint'
+    tokenUrl: 'http://some-token-endpoint/path',
+    logoutUrl: 'http://some-end-session-endpoint/path'
   })
+
+  expect(config.get('auth.origins'))
+    .toEqual([
+      'https://test.it',
+      'http://some-auth-endpoint',
+      'http://some-token-endpoint',
+      'http://some-end-session-endpoint'
+    ])
 })
 
 test('DefraId organisation not allowed', () => {


### PR DESCRIPTION
Domains returned within .well-known config may not be the same as the one that the config is hosted on. Any redirects to those domains that may be triggered need to be allowed in our form actions declaration within the Content Security Policy (CSP) header.

Fixes issue on test logging in with DefraId https://eaflood.atlassian.net/browse/CDMS-923