### PR TITLE
CDMS-999: Add decision reasons to the tests where appropriate

### DIFF
--- a/test/unit/models/customs-declarations.test.js
+++ b/test/unit/models/customs-declarations.test.js
@@ -373,7 +373,8 @@ test('an MRN, with no CHED, with no documents returns expected response', () => 
             decisionInternalFurtherDetail: [
               'E70'
             ],
-            checkCode: 'H220'
+            checkCode: 'H220',
+            decisionReasons: ['Decision Reason Here']
           }]
         }]
       },
@@ -395,7 +396,7 @@ test('an MRN, with no CHED, with no documents returns expected response', () => 
           match: false,
           decision: '',
           decisionDetail: 'No match',
-          decisionReason: null,
+          decisionReason: 'Decision Reason Here',
           departmentCode: 'HMI',
           isIuuOutcome: false,
           requiresChed: true
@@ -672,7 +673,7 @@ test('parses and returns document level decisions correctly', () => {
             documentReference: 'GBCHD2025.9710004',
             checkCode: 'H219',
             decisionCode: 'X00',
-            decisionReason: null,
+            decisionReason: 'Decision Reason Here',
             internalDecisionCode: 'E70'
           },
           {
@@ -744,7 +745,7 @@ test('parses and returns document level decisions correctly', () => {
           {
             decision: '',
             decisionDetail: 'No match',
-            decisionReason: null,
+            decisionReason: 'Decision Reason Here',
             departmentCode: 'PHSI',
             documentReference: 'GBCHD2025.9710004',
             id: expect.any(String),
@@ -895,7 +896,7 @@ test('the workaround for null checkCodes when a CHED is required to be created f
             documentReference: '',
             checkCode: null,
             decisionCode: 'X00',
-            decisionReason: null,
+            decisionReason: 'Decision Reason Here',
             internalDecisionCode: 'E70'
           },
           {


### PR DESCRIPTION
We want to ensure the decision reason is taken from the document level decisions and displayed to the user. Some of the tests were missing a value in this field, so it has been added and asserted upon.