### PR TITLE
CDMS-1288: Set the reporting date pickers to be readonly

### DIFF
--- a/src/plugins/template-renderer/vision.js
+++ b/src/plugins/template-renderer/vision.js
@@ -11,8 +11,8 @@ const dirname = path.dirname(fileURLToPath(import.meta.url))
 const nunjucksEnvironment = nunjucks.configure(
   [
     'node_modules/govuk-frontend/dist/',
-    'node_modules/@ministryofjustice/frontend',
-    path.resolve(dirname, '../../templates')
+    path.resolve(dirname, '../../templates'),
+    'node_modules/@ministryofjustice/frontend'
   ],
   {
     autoescape: true,

--- a/src/templates/includes/reporting-filters.njk
+++ b/src/templates/includes/reporting-filters.njk
@@ -11,7 +11,8 @@
       maxDate: todaysDate,
       errorMessage: {
         text: errors.startDate
-      } if errors.startDate
+      } if errors.startDate,
+      attributes: { readonly: '' }
     })
   }}
   {{
@@ -23,7 +24,8 @@
       maxDate: todaysDate,
       errorMessage: {
         text: errors.endDate
-      } if errors.endDate
+      } if errors.endDate,
+      attributes: { readonly: '' }
     })
   }}
   {{

--- a/src/templates/moj/components/date-picker/macro.njk
+++ b/src/templates/moj/components/date-picker/macro.njk
@@ -1,0 +1,3 @@
+{% macro mojDatePicker(params) %}
+  {%- include "moj/components/date-picker/template.njk" -%}
+{% endmacro %}

--- a/src/templates/moj/components/date-picker/template.njk
+++ b/src/templates/moj/components/date-picker/template.njk
@@ -1,0 +1,54 @@
+{# Copied from https://github.com/ministryofjustice/moj-frontend/blob/main/src/moj/components/date-picker/template.njk #}
+{# Allows for extra attributes to be passed through #}
+
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/macros/attributes.njk" import govukAttributes %}
+
+{% set classNames = "moj-js-datepicker-input " %}
+
+{%- if params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
+{% endif %}
+
+{% set attributes = {
+  "data-module": "moj-date-picker",
+  "data-min-date": {
+    value: params.minDate,
+    optional: true
+  },
+  "data-max-date": {
+    value: params.maxDate,
+    optional: true
+  },
+  "data-excluded-dates": {
+    value: params.excludedDates,
+    optional: true
+  },
+  "data-excluded-days": {
+    value: params.excludedDays,
+    optional: true
+  },
+  "data-leading-zeros": {
+    value: params.leadingZeros,
+    optional: true
+  },
+  "data-week-start-day": {
+    value: params.weekStartDay,
+    optional: true
+  }
+} %}
+
+<div class="moj-datepicker" {{ govukAttributes(attributes) }}>
+    {{ govukInput({
+      classes: classNames,
+      id: params.id,
+      name: params.name,
+      value: params.value,
+      autocomplete: "off",
+      attributes: params.attributes,
+      formGroup: params.formGroup,
+      label: params.label,
+      hint: params.hint,
+      errorMessage: params.errorMessage
+    }) }}
+</div>

--- a/test/unit/templates/date-picker.test.js
+++ b/test/unit/templates/date-picker.test.js
@@ -1,0 +1,44 @@
+import path from 'path'
+import { fileURLToPath } from 'node:url'
+import nunjucks from 'nunjucks'
+import { load } from 'cheerio'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const env = nunjucks.configure(
+  [
+    path.normalize(path.resolve(dirname, '../../../node_modules/govuk-frontend/dist')),
+    path.normalize(path.resolve(dirname, '../../../src/templates')),
+    path.normalize(path.resolve(dirname, '../../../node_modules/@ministryofjustice/frontend'))
+  ],
+  { trimBlocks: true, lstripBlocks: true }
+)
+
+const renderDatePicker = (params) => {
+  const rendered = env.renderString(
+    `{% from "moj/components/date-picker/macro.njk" import mojDatePicker %}{{ mojDatePicker(params) }}`,
+    { params }
+  )
+  return load(rendered)
+}
+
+describe('mojDatePicker template override', () => {
+  test('renders without attributes by default', () => {
+    const $ = renderDatePicker({ id: 'test-date', name: 'testDate', label: { text: 'Test date' } })
+    const input = $('input.moj-js-datepicker-input')
+    expect(input.length).toBe(1)
+    expect(input.attr('readonly')).toBeUndefined()
+  })
+
+  test('passes attributes to the input element', () => {
+    const $ = renderDatePicker({
+      id: 'test-date',
+      name: 'testDate',
+      label: { text: 'Test date' },
+      attributes: { readonly: '' }
+    })
+    const input = $('input.moj-js-datepicker-input')
+    expect(input.length).toBe(1)
+    expect(input.is('[readonly]')).toBe(true)
+  })
+})


### PR DESCRIPTION
The date picker that the MoJ provides does not support passing attributes which means we cannot set them to be readonly.
This change makes a copy of the date picker template and adds support for passing readonly to it.