### PR TITLE
CDMS-1456: quote fields in CSV

### DIFF
--- a/src/routes/reporting.csv.js
+++ b/src/routes/reporting.csv.js
@@ -72,13 +72,13 @@ const restrictedReportMapRowHandler = (value) => {
     value.itemNumber,
     value.commodityCode,
     value.checkCode,
-    value.description,
+    `"${value.description}"`,
     value.quantityOrWeight,
     value.chedReference,
     value.match,
     value.authority,
     value.decision,
-    value.decisionReasons,
+    `"${value.decisionReasons ?? ""}"`,
     value.declarantId,
     value.dispatchCountryCode
   ].join(',') + '\n'


### PR DESCRIPTION
- Adds quotations around the Description and Decision Reasons values in the CSV download
- Decision Reasons often contains null, hence the nullish coalescing